### PR TITLE
feat: Add TOON output format support (ARCH-1546)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,24 @@ murl http://localhost:3000/tools | jq -r '.name'
 | `-d, --data` | Add key=value or JSON data (repeatable) |
 | `-H, --header` | Add HTTP header (repeatable) |
 | `-v, --verbose` | Pretty-print output, show request debug info |
+| `--format toon` | Output in [TOON](https://github.com/toon-format/spec) format (token-efficient for LLMs) |
 | `--login` | Force OAuth re-authentication |
 | `--no-auth` | Skip all authentication |
 | `--version` | Show version info |
 | `--upgrade` | Upgrade to latest version |
+
+### TOON Output
+
+Use `--format toon` for [TOON](https://github.com/toon-format/spec) output, which uses fewer tokens than JSON when feeding results into LLM contexts. Requires the optional `python-toon` package:
+
+```bash
+pip install mcp-curl[toon]
+
+# List tools in TOON format
+murl https://mcp.deepwiki.com/mcp/tools --format toon
+
+# TOON uses tabular encoding for lists — field names declared once, then rows of values
+```
 
 ### OAuth
 

--- a/murl/cli.py
+++ b/murl/cli.py
@@ -350,6 +350,7 @@ OPTIONS:
   -d, --data <key=value|JSON>  Request data (repeatable)
   -H, --header <Key: Value>    HTTP header (repeatable)
   -v, --verbose                Pretty-print output, show request debug info
+  --format <toon>              Output format (toon = token-efficient for LLMs)
   --login                      Force OAuth re-authentication
   --no-auth                    Skip all authentication
   --version                    Version info
@@ -362,7 +363,7 @@ URL PATHS:
   /prompts          List prompts       /prompts/<name>     Get prompt
 
 OUTPUT:
-  stdout  Compact JSON (NDJSON for lists). Pretty-printed with -v.
+  stdout  Compact JSON (NDJSON for lists). Pretty-printed with -v. TOON with --format toon.
   stderr  Errors as {"error":"CODE","message":"...","code":N}
   exit    0=success  1=error  2=invalid args"""
     click.echo(help_text)
@@ -383,10 +384,12 @@ OUTPUT:
               help='Show version')
 @click.option('--upgrade', is_flag=True, callback=run_upgrade, expose_value=False, is_eager=True,
               help='Upgrade murl')
+@click.option('--format', 'output_format', type=click.Choice(['toon']), default=None,
+              help='Output format: toon (token-efficient for LLMs)')
 @click.option('--login', is_flag=True, help='Force OAuth re-authentication')
 @click.option('--no-auth', is_flag=True, help='Skip all authentication')
 def main(url: Optional[str], data_flags: Tuple[str, ...], header_flags: Tuple[str, ...],
-         verbose: bool, login: bool, no_auth: bool):
+         verbose: bool, output_format: Optional[str], login: bool, no_auth: bool):
     """murl - MCP Curl"""
     if url is None:
         output_error(
@@ -394,6 +397,14 @@ def main(url: Optional[str], data_flags: Tuple[str, ...], header_flags: Tuple[st
             message="URL argument is required",
             exit_code=ErrorCode.INVALID_ARGUMENT,
             suggestion="Run: murl --help"
+        )
+
+    if output_format and verbose:
+        output_error(
+            error_type="INVALID_ARGUMENT",
+            message="--format and --verbose are mutually exclusive",
+            exit_code=ErrorCode.INVALID_ARGUMENT,
+            suggestion="Use --format for alternative output or -v for verbose JSON, not both"
         )
 
     try:
@@ -449,6 +460,17 @@ def main(url: Optional[str], data_flags: Tuple[str, ...], header_flags: Tuple[st
         # --- Output ---
         if verbose:
             click.echo(json.dumps(result, indent=2))
+        elif output_format == 'toon':
+            try:
+                from toon import encode as toon_encode
+            except ImportError:
+                output_error(
+                    error_type="MISSING_DEPENDENCY",
+                    message="python-toon package is required for --format toon",
+                    exit_code=ErrorCode.GENERAL_ERROR,
+                    suggestion="Install it with: pip install mcp-curl[toon]"
+                )
+            click.echo(toon_encode(result))
         elif isinstance(result, list):
             for item in result:
                 click.echo(json.dumps(item, separators=(',', ':')))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,14 @@ Repository = "https://github.com/turlockmike/murl"
 Issues = "https://github.com/turlockmike/murl/issues"
 
 [project.optional-dependencies]
+toon = [
+    "python-toon>=0.1.3,<1.0.0",
+]
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "requests>=2.31.0",
+    "python-toon>=0.1.3,<1.0.0",
 ]
 
 [project.scripts]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -670,3 +670,110 @@ def test_cli_no_auth_skips_all_auth(mcp_server):
     assert not mock_get.called, "get_credentials should NOT be called with --no-auth"
     assert not mock_auth.called, "authorize should NOT be called with --no-auth"
     assert result.exit_code == 0
+
+
+# --- TOON format tests ---
+
+
+def test_toon_output_tools_list(mcp_server):
+    """--format toon outputs TOON format for tools/list."""
+    runner = CliRunner()
+    result = runner.invoke(main, [f"{mcp_server}/tools", "--format", "toon", "--no-auth"])
+
+    assert result.exit_code == 0
+    output = result.output.strip()
+    # Should contain tool names from test server
+    assert 'echo' in output
+    # Should NOT be valid JSON (it's TOON)
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(output)
+
+
+def test_toon_output_tool_call(mcp_server):
+    """--format toon outputs TOON format for tool call results."""
+    runner = CliRunner()
+    result = runner.invoke(main, [
+        f"{mcp_server}/tools/echo",
+        "-d", "message=hello",
+        "--format", "toon", "--no-auth"
+    ])
+
+    assert result.exit_code == 0
+    output = result.output.strip()
+    assert 'hello' in output
+
+
+def test_toon_format_verbose_mutually_exclusive():
+    """--format and --verbose together should error."""
+    runner = CliRunner()
+    result = runner.invoke(main, [
+        "http://localhost:8765/tools", "--format", "toon", "-v", "--no-auth"
+    ])
+
+    assert result.exit_code == 2
+    error_obj = json.loads(result.output.strip())
+    assert error_obj["error"] == "INVALID_ARGUMENT"
+    assert "mutually exclusive" in error_obj["message"]
+
+
+def test_toon_roundtrip_tools_list(mcp_server):
+    """TOON output can be decoded back to the original data."""
+    from toon import decode as toon_decode
+
+    runner = CliRunner()
+
+    # Get JSON output
+    json_result = runner.invoke(main, [f"{mcp_server}/tools", "--no-auth"])
+    json_data = parse_ndjson(json_result.output)
+
+    # Get TOON output
+    toon_result = runner.invoke(main, [f"{mcp_server}/tools", "--format", "toon", "--no-auth"])
+    toon_data = toon_decode(toon_result.output.strip())
+
+    assert toon_data == json_data
+
+
+def test_toon_missing_dependency(mcp_server):
+    """--format toon with missing python-toon shows helpful error."""
+    from unittest.mock import patch
+    import builtins
+
+    original_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == 'toon':
+            raise ImportError("No module named 'toon'")
+        return original_import(name, *args, **kwargs)
+
+    runner = CliRunner()
+    with patch.object(builtins, '__import__', side_effect=mock_import):
+        result = runner.invoke(main, [f"{mcp_server}/tools", "--format", "toon", "--no-auth"])
+
+    assert result.exit_code == 1
+    error_obj = json.loads(result.output.strip())
+    assert error_obj["error"] == "MISSING_DEPENDENCY"
+    assert "mcp-curl[toon]" in error_obj["suggestion"]
+
+
+def test_toon_nested_objects(mcp_server):
+    """TOON handles tools with nested inputSchema correctly."""
+    from toon import decode as toon_decode
+
+    runner = CliRunner()
+    toon_result = runner.invoke(main, [f"{mcp_server}/tools", "--format", "toon", "--no-auth"])
+
+    assert toon_result.exit_code == 0
+    decoded = toon_decode(toon_result.output.strip())
+
+    # Verify nested inputSchema survived the roundtrip
+    tools_with_schema = [t for t in decoded if 'inputSchema' in t]
+    assert len(tools_with_schema) > 0
+    for tool in tools_with_schema:
+        assert isinstance(tool['inputSchema'], dict)
+
+
+def test_toon_empty_result():
+    """TOON handles empty list results without error."""
+    from toon import encode as toon_encode
+    result = toon_encode([])
+    assert result == '[0]:'


### PR DESCRIPTION
## Summary

- Adds `--format toon` option for [TOON](https://github.com/toon-format/spec) output, a token-efficient serialization format (~40% fewer tokens than JSON for structured data)
- Optional dependency (`pip install mcp-curl[toon]`) with lazy import and clear error messaging
- Mutual exclusion with `--verbose` enforced at runtime

## Details

TOON (Token Oriented Object Notation) declares field names once in headers and emits CSV-like rows for uniform arrays — purpose-built for LLM context windows. The `python-toon` library handles encoding, with a version ceiling (`<1.0.0`) to guard against breaking changes in the pre-1.0 spec.

**Files changed:**
- `murl/cli.py` — `--format` option, TOON output branch, updated help text
- `pyproject.toml` — `[toon]` extras group, added to dev deps
- `tests/test_cli.py` — 7 new tests (list output, tool call, mutual exclusion, roundtrip, missing dependency, nested objects, empty results)
- `README.md` — documented `--format toon` with install instructions

## Test plan

- [x] All 64 tests pass (57 existing + 7 new)
- [ ] Manual: `murl <server>/tools --format toon --no-auth` produces TOON tabular output
- [ ] Manual: `murl <server>/tools --format toon -v` errors with mutual exclusion message
- [ ] Roundtrip: TOON output decodes back to original JSON data

🤖 Generated with [Claude Code](https://claude.com/claude-code)