### PR TITLE
fix(auth): host-level fallback for OAuth metadata discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,22 @@ murl http://localhost:3000/tools | jq -r '.name'
 | `-d, --data` | Add key=value or JSON data (repeatable) |
 | `-H, --header` | Add HTTP header (repeatable) |
 | `-v, --verbose` | Pretty-print output, show request debug info |
+| `--format toon` | Output in [TOON](https://github.com/toon-format/spec) format (token-efficient for LLMs) |
 | `--login` | Force OAuth re-authentication |
 | `--no-auth` | Skip all authentication |
 | `--version` | Show version info |
 | `--upgrade` | Upgrade to latest version |
+
+### TOON Output
+
+Use `--format toon` for [TOON](https://github.com/toon-format/spec) output, which uses fewer tokens than JSON when feeding results into LLM contexts. Requires the optional `python-toon` package:
+
+```bash
+pip install mcp-curl[toon]
+
+# List tools in TOON format — produces fewer tokens than JSON for structured data
+murl https://mcp.deepwiki.com/mcp/tools --format toon
+```
 
 ### OAuth
 

--- a/murl/__init__.py
+++ b/murl/__init__.py
@@ -1,3 +1,3 @@
 """murl - A curl-like CLI tool for Model Context Protocol (MCP) servers."""
 
-__version__ = "0.3.2"
+__version__ = "0.4.0"

--- a/murl/auth.py
+++ b/murl/auth.py
@@ -135,10 +135,16 @@ def discover_auth_server_metadata(issuer_url: str) -> dict:
       1. /.well-known/oauth-authorization-server/tenant1  (RFC 8414)
       2. /.well-known/openid-configuration/tenant1        (OIDC path insertion)
       3. /tenant1/.well-known/openid-configuration        (OIDC path append)
+      4. /.well-known/oauth-authorization-server          (host-level fallback)
+      5. /.well-known/openid-configuration                (host-level OIDC fallback)
 
     For issuer without path (e.g. https://auth.example.com), MUST try:
       1. /.well-known/oauth-authorization-server           (RFC 8414)
       2. /.well-known/openid-configuration                 (OIDC)
+
+    Host-level fallback covers servers (e.g. mcp.atlassian.com) that publish
+    a single metadata document at the host root and route 401/404 for
+    path-prefixed well-known URLs.
     """
     parsed = urllib.parse.urlparse(issuer_url)
     base = f"{parsed.scheme}://{parsed.netloc}"
@@ -149,6 +155,8 @@ def discover_auth_server_metadata(issuer_url: str) -> dict:
         urls_to_try.append(f"{base}/.well-known/oauth-authorization-server{path}")
         urls_to_try.append(f"{base}/.well-known/openid-configuration{path}")
         urls_to_try.append(f"{base}{path}/.well-known/openid-configuration")
+        urls_to_try.append(f"{base}/.well-known/oauth-authorization-server")
+        urls_to_try.append(f"{base}/.well-known/openid-configuration")
     else:
         urls_to_try.append(f"{base}/.well-known/oauth-authorization-server")
         urls_to_try.append(f"{base}/.well-known/openid-configuration")
@@ -200,12 +208,15 @@ def discover_metadata(server_url: str) -> dict:
     base = f"{parsed.scheme}://{parsed.netloc}"
     path = parsed.path.rstrip("/")
 
-    # Try RFC 8414 then OIDC, path-aware
+    # Try RFC 8414 then OIDC, path-aware, with host-level fallback for servers
+    # (e.g. mcp.atlassian.com) that publish metadata only at the host root.
     urls_to_try = []
     if path:
         urls_to_try.append(f"{base}/.well-known/oauth-authorization-server{path}")
         urls_to_try.append(f"{base}/.well-known/openid-configuration{path}")
         urls_to_try.append(f"{base}{path}/.well-known/openid-configuration")
+        urls_to_try.append(f"{base}/.well-known/oauth-authorization-server")
+        urls_to_try.append(f"{base}/.well-known/openid-configuration")
     else:
         urls_to_try.append(f"{base}/.well-known/oauth-authorization-server")
         urls_to_try.append(f"{base}/.well-known/openid-configuration")

--- a/murl/auth.py
+++ b/murl/auth.py
@@ -1,9 +1,18 @@
-"""OAuth 2.0 Dynamic Client Registration (RFC 7591) with PKCE."""
+"""OAuth 2.0 authorization for MCP (2025-11-25 spec).
+
+Implements:
+- Protected Resource Metadata discovery (RFC 9728)
+- Authorization Server Metadata with OIDC fallback (RFC 8414)
+- Dynamic Client Registration (RFC 7591)
+- PKCE with S256 (OAuth 2.1)
+- Resource Indicators (RFC 8707)
+"""
 
 import base64
 import hashlib
 import html
 import json
+import re
 import secrets
 import threading
 import time
@@ -22,52 +31,213 @@ class OAuthError(Exception):
     """Raised when an OAuth operation fails."""
 
 
+# ---------------------------------------------------------------------------
+# WWW-Authenticate header parsing
+# ---------------------------------------------------------------------------
+
+def parse_www_authenticate(header_value: str) -> dict:
+    """Parse a WWW-Authenticate Bearer header into a dict of parameters.
+
+    Per MCP 2025-11-25 §Protected Resource Metadata Discovery Requirements,
+    clients MUST be able to parse WWW-Authenticate headers and respond
+    appropriately to HTTP 401/403 responses.
+
+    Handles: Bearer resource_metadata="...", scope="...", error="..."
+    Returns dict with keys like resource_metadata, scope, error, error_description.
+    """
+    result = {}
+    # Strip the "Bearer" scheme prefix if present
+    value = header_value.strip()
+    if value.lower().startswith("bearer"):
+        value = value[len("bearer"):].strip()
+        # Handle case where there's nothing after Bearer (just "Bearer")
+        if not value:
+            return result
+
+    # Parse key="value" pairs (values may or may not be quoted)
+    for match in re.finditer(r'(\w+)\s*=\s*"([^"]*)"', value):
+        result[match.group(1)] = match.group(2)
+    # Also handle unquoted values
+    for match in re.finditer(r'(\w+)\s*=\s*([^",\s]+)', value):
+        key = match.group(1)
+        if key not in result:  # quoted takes precedence
+            result[key] = match.group(2)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Discovery: Protected Resource Metadata (RFC 9728)
+# ---------------------------------------------------------------------------
+
+def discover_resource_metadata(server_url: str, resource_metadata_url: Optional[str] = None) -> dict:
+    """Fetch Protected Resource Metadata per RFC 9728.
+
+    Per MCP 2025-11-25 §Authorization Server Location, clients MUST use
+    Protected Resource Metadata for authorization server discovery.
+
+    Per §Protected Resource Metadata Discovery Requirements, clients MUST:
+      - Use the resource_metadata URL from WWW-Authenticate when present.
+      - Otherwise fall back to well-known URIs in this order:
+        1. /.well-known/oauth-protected-resource/<path>  (path-aware)
+        2. /.well-known/oauth-protected-resource          (root)
+
+    Returns the metadata dict, which MUST contain 'authorization_servers'.
+    Raises OAuthError if discovery fails.
+    """
+    urls_to_try = []
+
+    if resource_metadata_url:
+        urls_to_try.append(resource_metadata_url)
+    else:
+        parsed = urllib.parse.urlparse(server_url)
+        base = f"{parsed.scheme}://{parsed.netloc}"
+        path = parsed.path.rstrip("/")
+
+        if path:
+            urls_to_try.append(f"{base}/.well-known/oauth-protected-resource{path}")
+        urls_to_try.append(f"{base}/.well-known/oauth-protected-resource")
+
+    for url in urls_to_try:
+        try:
+            resp = httpx.get(url, follow_redirects=True, timeout=10)
+        except httpx.HTTPError:
+            continue
+
+        if resp.status_code == 200:
+            try:
+                meta = resp.json()
+            except json.JSONDecodeError:
+                continue
+            if isinstance(meta, dict) and "authorization_servers" in meta:
+                return meta
+            # Valid JSON but missing required field — keep trying
+            continue
+
+    raise OAuthError(
+        "Could not discover Protected Resource Metadata (RFC 9728). "
+        "The server may not support OAuth, or the well-known endpoint is unreachable."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Discovery: Authorization Server Metadata (RFC 8414 + OIDC)
+# ---------------------------------------------------------------------------
+
+def discover_auth_server_metadata(issuer_url: str) -> dict:
+    """Fetch Authorization Server Metadata with OIDC Discovery fallback.
+
+    Per MCP 2025-11-25 §Authorization Server Metadata Discovery, clients
+    MUST attempt multiple well-known endpoints.  Priority order follows
+    RFC 8414 §3.1 and §5 (OIDC interop).
+
+    For issuer with path (e.g. https://auth.example.com/tenant1), MUST try:
+      1. /.well-known/oauth-authorization-server/tenant1  (RFC 8414)
+      2. /.well-known/openid-configuration/tenant1        (OIDC path insertion)
+      3. /tenant1/.well-known/openid-configuration        (OIDC path append)
+
+    For issuer without path (e.g. https://auth.example.com), MUST try:
+      1. /.well-known/oauth-authorization-server           (RFC 8414)
+      2. /.well-known/openid-configuration                 (OIDC)
+    """
+    parsed = urllib.parse.urlparse(issuer_url)
+    base = f"{parsed.scheme}://{parsed.netloc}"
+    path = parsed.path.rstrip("/")
+
+    urls_to_try = []
+    if path:
+        urls_to_try.append(f"{base}/.well-known/oauth-authorization-server{path}")
+        urls_to_try.append(f"{base}/.well-known/openid-configuration{path}")
+        urls_to_try.append(f"{base}{path}/.well-known/openid-configuration")
+    else:
+        urls_to_try.append(f"{base}/.well-known/oauth-authorization-server")
+        urls_to_try.append(f"{base}/.well-known/openid-configuration")
+
+    for url in urls_to_try:
+        try:
+            resp = httpx.get(url, follow_redirects=True, timeout=10)
+        except httpx.HTTPError:
+            continue
+
+        if resp.status_code == 200:
+            try:
+                meta = resp.json()
+            except json.JSONDecodeError:
+                continue
+            if isinstance(meta, dict) and "token_endpoint" in meta:
+                # Tag the source so callers can distinguish RFC 8414 from OIDC.
+                # OIDC Provider Metadata does not define code_challenge_methods_supported,
+                # so its absence from an OIDC endpoint is expected (see PKCE check).
+                meta["_discovery_source"] = (
+                    "oidc" if "openid-configuration" in url else "rfc8414"
+                )
+                return meta
+
+    raise OAuthError(
+        f"Could not discover Authorization Server Metadata for {issuer_url}. "
+        "Tried OAuth 2.0 (RFC 8414) and OpenID Connect discovery endpoints."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Legacy discovery (kept for backwards compat with servers that don't
+# implement RFC 9728 yet)
+# ---------------------------------------------------------------------------
+
 def _auth_base_url(server_url: str) -> str:
-    """Extract scheme + host from server URL (strip path per MCP spec)."""
+    """Extract scheme + host from server URL."""
     parsed = urllib.parse.urlparse(server_url)
     return f"{parsed.scheme}://{parsed.netloc}"
 
 
 def discover_metadata(server_url: str) -> dict:
-    """Fetch OAuth 2.0 Authorization Server Metadata.
+    """Legacy: fetch OAuth 2.0 Authorization Server Metadata directly.
 
-    Tries /.well-known/oauth-authorization-server first.
-    Falls back to sensible defaults if 404.
+    Tries /.well-known/oauth-authorization-server first, with OIDC fallback.
+    Falls back to sensible defaults if both 404.
     """
-    base = _auth_base_url(server_url)
-    url = f"{base}/.well-known/oauth-authorization-server"
+    parsed = urllib.parse.urlparse(server_url)
+    base = f"{parsed.scheme}://{parsed.netloc}"
+    path = parsed.path.rstrip("/")
 
-    try:
-        resp = httpx.get(url, follow_redirects=True, timeout=10)
-    except httpx.HTTPError:
-        # Network error — fall back to defaults
-        return {
-            "authorization_endpoint": f"{base}/authorize",
-            "token_endpoint": f"{base}/token",
-            "registration_endpoint": f"{base}/register",
-        }
+    # Try RFC 8414 then OIDC, path-aware
+    urls_to_try = []
+    if path:
+        urls_to_try.append(f"{base}/.well-known/oauth-authorization-server{path}")
+        urls_to_try.append(f"{base}/.well-known/openid-configuration{path}")
+        urls_to_try.append(f"{base}{path}/.well-known/openid-configuration")
+    else:
+        urls_to_try.append(f"{base}/.well-known/oauth-authorization-server")
+        urls_to_try.append(f"{base}/.well-known/openid-configuration")
 
-    if resp.status_code == 200:
+    for url in urls_to_try:
         try:
-            return resp.json()
-        except json.JSONDecodeError as exc:
-            raise OAuthError("Invalid JSON in OAuth metadata response") from exc
+            resp = httpx.get(url, follow_redirects=True, timeout=10)
+        except httpx.HTTPError:
+            continue
 
-    if resp.status_code == 404:
-        return {
-            "authorization_endpoint": f"{base}/authorize",
-            "token_endpoint": f"{base}/token",
-            "registration_endpoint": f"{base}/register",
-        }
+        if resp.status_code == 200:
+            try:
+                return resp.json()
+            except json.JSONDecodeError as exc:
+                raise OAuthError("Invalid JSON in OAuth metadata response") from exc
 
-    raise OAuthError(
-        f"Failed to fetch OAuth metadata ({resp.status_code}): {resp.text}"
-    )
+    # All attempts failed — fall back to defaults
+    return {
+        "authorization_endpoint": f"{base}/authorize",
+        "token_endpoint": f"{base}/token",
+        "registration_endpoint": f"{base}/register",
+    }
 
 
 def register_client(registration_endpoint: str, redirect_uri: str) -> dict:
     """Dynamic Client Registration (RFC 7591).
 
+    Per MCP 2025-11-25 §Client Registration Approaches, DCR is a MAY-level
+    fallback used when the client has no pre-registered credentials and the
+    auth server does not support Client ID Metadata Documents.
+
+    Registers as a public client (token_endpoint_auth_method=none).
     Returns dict with at least ``client_id`` and optionally ``client_secret``.
     """
     payload = {
@@ -101,14 +271,15 @@ def register_client(registration_endpoint: str, redirect_uri: str) -> dict:
 # ---------------------------------------------------------------------------
 
 class _CallbackHandler(BaseHTTPRequestHandler):
-    """Tiny HTTP handler that captures the OAuth callback."""
+    """Tiny HTTP handler that captures the OAuth callback.
 
-    # Shared across instances via class attrs set before serve_forever()
-    auth_code: Optional[str] = None
-    auth_error: Optional[str] = None
-    expected_state: Optional[str] = None
+    Per-request state is stored on ``self.server.callback_state`` (a dict set
+    by ``_run_callback_server``) instead of class attributes, so concurrent
+    ``authorize()`` calls don't race-write to shared slots.
+    """
 
     def do_GET(self):  # noqa: N802
+        ctx = self.server.callback_state
         parsed = urllib.parse.urlparse(self.path)
         params = urllib.parse.parse_qs(parsed.query)
 
@@ -119,25 +290,25 @@ class _CallbackHandler(BaseHTTPRequestHandler):
 
         # Validate state
         state = params.get("state", [None])[0]
-        if state != self.expected_state:
-            _CallbackHandler.auth_error = "State mismatch"
+        if state != ctx["expected_state"]:
+            ctx["auth_error"] = "State mismatch"
             self._respond("Authorization failed: state mismatch.")
             return
 
         error = params.get("error", [None])[0]
         if error:
             desc = params.get("error_description", [error])[0]
-            _CallbackHandler.auth_error = desc
+            ctx["auth_error"] = desc
             self._respond(f"Authorization failed: {desc}")
             return
 
         code = params.get("code", [None])[0]
         if not code:
-            _CallbackHandler.auth_error = "No authorization code received"
+            ctx["auth_error"] = "No authorization code received"
             self._respond("Authorization failed: no code received.")
             return
 
-        _CallbackHandler.auth_code = code
+        ctx["auth_code"] = code
         self._respond("Authorization successful! You can close this tab.")
 
     def _respond(self, body: str):
@@ -158,22 +329,29 @@ class _CallbackHandler(BaseHTTPRequestHandler):
 
 def _run_callback_server(port: int, state: str, timeout: float) -> str:
     """Start a local server, wait for the callback, return the auth code."""
-    _CallbackHandler.auth_code = None
-    _CallbackHandler.auth_error = None
-    _CallbackHandler.expected_state = state
-
-    server = HTTPServer(("127.0.0.1", port), _CallbackHandler)
+    # Bind to "localhost" (not "127.0.0.1") so the listener matches the
+    # redirect_uri host.  On machines where localhost resolves to ::1 first,
+    # binding 127.0.0.1 would miss IPv6 callbacks from the browser.
+    server = HTTPServer(("localhost", port), _CallbackHandler)
     server.timeout = timeout
+    # Per-instance state dict avoids class-level attributes that would be
+    # shared (and race-written) across concurrent authorize() calls.
+    server.callback_state = {
+        "auth_code": None,
+        "auth_error": None,
+        "expected_state": state,
+    }
 
     # Handle a single request (the callback)
     server.handle_request()
     server.server_close()
 
-    if _CallbackHandler.auth_error:
-        raise OAuthError(_CallbackHandler.auth_error)
-    if not _CallbackHandler.auth_code:
+    ctx = server.callback_state
+    if ctx["auth_error"]:
+        raise OAuthError(ctx["auth_error"])
+    if not ctx["auth_code"]:
         raise OAuthError("Timed out waiting for authorization callback")
-    return _CallbackHandler.auth_code
+    return ctx["auth_code"]
 
 
 # ---------------------------------------------------------------------------
@@ -192,45 +370,198 @@ def _generate_pkce() -> tuple:
 # Public API
 # ---------------------------------------------------------------------------
 
-def authorize(server_url: str) -> dict:
+def _canonical_resource_uri(server_url: str) -> str:
+    """Build the canonical resource URI for RFC 8707 resource parameter.
+
+    Per MCP 2025-11-25 §Resource Parameter Implementation:
+      - MUST use the canonical URI of the MCP server (RFC 8707 §2).
+      - MUST NOT include fragments.
+      - SHOULD use the form without trailing slash unless semantically significant.
+      - SHOULD provide the most specific URI possible.
+    """
+    parsed = urllib.parse.urlparse(server_url)
+    # Reconstruct without fragment or query; keep path as-is (no synthetic "/")
+    # so that "https://example.com" stays "https://example.com" per spec SHOULD.
+    return urllib.parse.urlunparse((
+        parsed.scheme, parsed.netloc, parsed.path, "", "", ""
+    ))
+
+
+def _validate_auth_server_origin(auth_server_url: str, server_url: str) -> None:
+    """Validate that the authorization server shares the same origin as the MCP server.
+
+    RFC 9728 §3 requires that clients verify the authorization server's hostname
+    matches the resource server.  Without this check, a malicious MCP endpoint
+    could redirect the OAuth flow to an attacker-controlled authorization server
+    via a crafted ``authorization_servers`` value.
+
+    Raises OAuthError if the hostnames don't match.
+    """
+    resource_parsed = urllib.parse.urlparse(server_url)
+    auth_parsed = urllib.parse.urlparse(auth_server_url)
+
+    if not auth_parsed.hostname:
+        raise OAuthError(
+            f"Invalid authorization server URL: {auth_server_url}"
+        )
+
+    # Compare hostnames (case-insensitive per RFC 4343).
+    if resource_parsed.hostname.lower() != auth_parsed.hostname.lower():
+        raise OAuthError(
+            f"Authorization server hostname '{auth_parsed.hostname}' does not match "
+            f"MCP server hostname '{resource_parsed.hostname}'. "
+            f"This could indicate a malicious server redirect. "
+            f"If this is expected, use --client-id to supply pre-registered credentials "
+            f"and bypass discovery."
+        )
+
+
+def authorize(server_url: str, www_authenticate: Optional[str] = None,
+              scope: Optional[str] = None, client_id: Optional[str] = None,
+              client_secret: Optional[str] = None,
+              callback_port: Optional[int] = None) -> dict:
     """Run the full OAuth flow and return credential dict.
 
-    Steps: metadata discovery -> client registration -> PKCE browser auth -> token exchange.
+    Follows MCP 2025-11-25 authorization spec:
+      1. Protected Resource Metadata discovery (RFC 9728)
+      2. Authorization Server Metadata discovery (RFC 8414 + OIDC)
+      3. Client registration (pre-configured or Dynamic Client Registration)
+      4. PKCE browser auth with resource parameter (RFC 8707)
+      5. Token exchange with resource parameter
 
-    The returned dict contains: client_id, client_secret (maybe None),
-    access_token, refresh_token, expires_at, token_endpoint,
-    registration_endpoint, server_url.
+    Args:
+        server_url: The MCP server base URL.
+        www_authenticate: Optional WWW-Authenticate header value from a 401 response.
+        scope: Optional scope string to request (from WWW-Authenticate or resource metadata).
+        client_id: Optional pre-registered OAuth client ID. Skips Dynamic Client Registration.
+        client_secret: Optional pre-registered OAuth client secret.
+        callback_port: Optional fixed port for the OAuth callback server.
+            Required when using pre-registered credentials with a fixed redirect URI.
+
+    Returns dict with: client_id, client_secret, access_token, refresh_token,
+    expires_at, token_endpoint, registration_endpoint, server_url, resource_uri.
     """
     import click
 
-    # 1. Metadata
+    resource_uri = _canonical_resource_uri(server_url)
+
+    # --- Step 1: Discovery ---
+    # Try the full RFC 9728 discovery chain first. If that fails (server doesn't
+    # implement Protected Resource Metadata), fall back to legacy direct discovery.
     click.echo("Discovering OAuth metadata...", err=True)
-    meta = discover_metadata(server_url)
+
+    www_auth_params = parse_www_authenticate(www_authenticate) if www_authenticate else {}
+    resource_metadata_url = www_auth_params.get("resource_metadata")
+
+    # MCP 2025-11-25 §Scope Selection Strategy — priority order:
+    #   1. Explicit scope param (from caller, e.g. 403 step-up)
+    #   2. scope from WWW-Authenticate header
+    #   3. scopes_supported from Protected Resource Metadata
+    #   4. Omit scope entirely if none available
+    if not scope and www_auth_params.get("scope"):
+        scope = www_auth_params["scope"]
+
+    # Two-phase discovery: first try RFC 9728 resource metadata, then fetch
+    # auth server metadata from the advertised issuer.  Only fall back to
+    # legacy discovery when resource metadata itself is unavailable — if the
+    # issuer is found but its metadata fetch fails, that error must propagate.
+    try:
+        resource_meta = discover_resource_metadata(server_url, resource_metadata_url)
+    except OAuthError:
+        # Resource metadata unavailable — fall back to legacy direct discovery
+        # for servers not yet on MCP 2025-11-25.
+        auth_server_meta = discover_metadata(server_url)
+    else:
+        # Extract scope from resource metadata if not already set
+        if not scope and resource_meta.get("scopes_supported"):
+            scope = " ".join(resource_meta["scopes_supported"])
+
+        # Get the first authorization server
+        auth_servers = resource_meta.get("authorization_servers", [])
+        if not auth_servers:
+            raise OAuthError("Protected Resource Metadata has empty authorization_servers")
+
+        issuer_url = auth_servers[0]
+
+        # RFC 9728 §3: validate that the authorization server's hostname
+        # matches the MCP server to prevent redirect attacks.
+        _validate_auth_server_origin(issuer_url, server_url)
+
+        # Fetch auth server metadata (RFC 8414 + OIDC fallback).
+        # Errors here propagate — the issuer was explicitly advertised.
+        auth_server_meta = discover_auth_server_metadata(issuer_url)
+
+    meta = auth_server_meta
     auth_endpoint = meta["authorization_endpoint"]
     token_endpoint = meta["token_endpoint"]
     reg_endpoint = meta.get("registration_endpoint")
 
-    if not reg_endpoint:
+    # MCP 2025-11-25 §Authorization Code Protection: clients MUST verify PKCE
+    # support via code_challenge_methods_supported before proceeding, and MUST
+    # use S256 when technically capable (OAuth 2.1 §4.1.1).
+    #
+    # However, OIDC Provider Metadata (OpenID Connect Discovery 1.0) does NOT
+    # define code_challenge_methods_supported — it's an OAuth 2.0 AS Metadata
+    # field.  Major IDPs like Okta serve OIDC metadata without this field yet
+    # fully support S256 PKCE.  The MCP spec acknowledges this:
+    #   "this field is commonly included by OpenID providers"
+    # When metadata comes from an OIDC endpoint, we warn but proceed with S256
+    # rather than blocking all Okta/OIDC-based servers.
+    challenge_methods = meta.get("code_challenge_methods_supported")
+    discovery_source = meta.get("_discovery_source", "unknown")
+    if challenge_methods is None:
+        if discovery_source == "oidc":
+            click.echo(
+                "Warning: OIDC metadata does not include "
+                "code_challenge_methods_supported; assuming S256 is supported.",
+                err=True,
+            )
+        else:
+            raise OAuthError(
+                "Authorization server does not advertise PKCE support "
+                "(code_challenge_methods_supported). Cannot proceed securely."
+            )
+    elif "S256" not in challenge_methods:
         raise OAuthError(
-            "Server does not advertise a registration endpoint. "
-            "Manual client registration may be required."
+            "Authorization server does not support S256 PKCE code challenge method"
         )
 
-    # 2. Pick a random port for the callback
+    # --- Step 2: Callback port ---
     import socket
-    with socket.socket() as s:
-        s.bind(("127.0.0.1", 0))
-        port = s.getsockname()[1]
+    if callback_port:
+        port = callback_port
+    else:
+        with socket.socket() as s:
+            s.bind(("127.0.0.1", 0))
+            port = s.getsockname()[1]
 
-    redirect_uri = f"http://127.0.0.1:{port}/callback"
+    # Use "localhost" rather than "127.0.0.1" — most IDPs (Okta, Cognito, etc.)
+    # register redirect URIs with "localhost".  Both resolve to loopback, but
+    # IDPs do exact string matching on the redirect_uri parameter.
+    redirect_uri = f"http://localhost:{port}/callback"
 
-    # 3. Dynamic client registration
-    click.echo("Registering client...", err=True)
-    reg = register_client(reg_endpoint, redirect_uri)
-    client_id = reg["client_id"]
-    client_secret = reg.get("client_secret")
+    # --- Step 3: Client registration ---
+    # MCP 2025-11-25 §Client Registration Approaches priority:
+    #   1. Pre-registered credentials (--client-id)
+    #   2. Client ID Metadata Documents (not implemented — SHOULD level)
+    #   3. Dynamic Client Registration (fallback)
+    #   4. Prompt user (we raise with guidance to use --client-id)
+    if client_id:
+        click.echo("Using pre-configured client credentials...", err=True)
+    else:
+        if not reg_endpoint:
+            raise OAuthError(
+                "Server does not advertise a registration endpoint. "
+                "Use --client-id to provide pre-registered credentials."
+            )
+        click.echo("Registering client...", err=True)
+        reg = register_client(reg_endpoint, redirect_uri)
+        client_id = reg["client_id"]
+        client_secret = reg.get("client_secret")
 
-    # 4. PKCE + authorization URL
+    # --- Step 4: PKCE + authorization URL ---
+    # MCP 2025-11-25 §Resource Parameter Implementation: resource MUST be
+    # included in both authorization requests and token requests (RFC 8707).
     code_verifier, code_challenge = _generate_pkce()
     state = secrets.token_urlsafe(32)
 
@@ -241,13 +572,16 @@ def authorize(server_url: str) -> dict:
         "code_challenge": code_challenge,
         "code_challenge_method": "S256",
         "state": state,
+        "resource": resource_uri,
     }
+    if scope:
+        auth_params["scope"] = scope
     auth_url = f"{auth_endpoint}?{urllib.parse.urlencode(auth_params)}"
 
     click.echo("Opening browser for authorization...", err=True)
     webbrowser.open(auth_url)
 
-    # 5. Wait for callback in a background thread so we can show a message
+    # --- Step 5: Wait for callback ---
     code_result = [None]
     error_result = [None]
 
@@ -269,7 +603,8 @@ def authorize(server_url: str) -> dict:
 
     auth_code = code_result[0]
 
-    # 6. Token exchange
+    # --- Step 6: Token exchange ---
+    # RFC 8707: resource MUST be included in token requests (MCP 2025-11-25).
     click.echo("Exchanging authorization code for token...", err=True)
     token_data = {
         "grant_type": "authorization_code",
@@ -277,6 +612,7 @@ def authorize(server_url: str) -> dict:
         "client_id": client_id,
         "redirect_uri": redirect_uri,
         "code_verifier": code_verifier,
+        "resource": resource_uri,
     }
     if client_secret:
         token_data["client_secret"] = client_secret
@@ -302,6 +638,7 @@ def authorize(server_url: str) -> dict:
         "token_endpoint": token_endpoint,
         "registration_endpoint": reg_endpoint,
         "server_url": server_url,
+        "resource_uri": resource_uri,
     }
     click.echo("Authorization successful!", err=True)
     return creds
@@ -309,6 +646,11 @@ def authorize(server_url: str) -> dict:
 
 def refresh_token(creds: dict) -> dict:
     """Use a refresh token to get a new access token.
+
+    Per MCP 2025-11-25 §Resource Parameter Implementation, the ``resource``
+    parameter MUST be included in token requests — including refresh requests
+    (RFC 8707 §2).  This ensures the refreshed token is audience-bound to the
+    same MCP server.
 
     Returns updated credential dict.
     Raises OAuthError if refresh fails.
@@ -324,6 +666,9 @@ def refresh_token(creds: dict) -> dict:
     }
     if creds.get("client_secret"):
         data["client_secret"] = creds["client_secret"]
+    # RFC 8707: resource MUST be included in token requests (MCP 2025-11-25).
+    if creds.get("resource_uri"):
+        data["resource"] = creds["resource_uri"]
 
     resp = httpx.post(creds["token_endpoint"], data=data, timeout=10)
     if resp.status_code != 200:

--- a/murl/cli.py
+++ b/murl/cli.py
@@ -2,12 +2,18 @@
 
 import asyncio
 import json
+import logging
 import os
 import re
 import subprocess
 import sys
 import urllib.parse
 from typing import Dict, Any, Tuple, Optional
+
+# The MCP SDK logs a noisy warning when the server returns 404 on session
+# DELETE (valid per MCP 2025-11-25 §Session Management — 404 means "session
+# already gone").  Suppress it so users don't see spurious errors.
+logging.getLogger("mcp.client.streamable_http").setLevel(logging.ERROR)
 
 # Python 3.10 compatibility: ExceptionGroup was added in 3.11
 try:
@@ -19,8 +25,9 @@ import click
 from mcp import ClientSession
 from mcp.client.streamable_http import streamable_http_client
 from murl import __version__
+import httpx as _httpx
 from murl.token_store import get_credentials, save_credentials, clear_credentials, is_expired
-from murl.auth import authorize, refresh_token, OAuthError
+from murl.auth import authorize, refresh_token, OAuthError, parse_www_authenticate
 
 # Optional TOON format support (pip install mcp-curl[toon])
 try:
@@ -212,12 +219,20 @@ def map_virtual_path_to_method(virtual_path: str, data: Dict[str, Any]) -> Tuple
         if len(parts) == 1:
             return 'resources/list', {}
         else:
-            file_path = '/'.join(parts[1:])
-            if not file_path or file_path == '':
+            resource_path = '/'.join(parts[1:])
+            if not resource_path or resource_path == '':
                 raise ValueError("Invalid resources path: path cannot be empty after /resources/")
-            if not file_path.startswith('/'):
-                file_path = '/' + file_path
-            uri = f'file://{file_path}'
+            # If the path looks like a URI scheme (contains ://), use it as-is.
+            # Otherwise, construct a file:// URI for backwards compatibility.
+            if '://' in resource_path:
+                uri = resource_path
+            else:
+                if not resource_path.startswith('/'):
+                    resource_path = '/' + resource_path
+                uri = f'file://{resource_path}'
+            # Allow -d uri=... to override the path-derived URI
+            if 'uri' in data:
+                uri = data.pop('uri')
             return 'resources/read', {'uri': uri, **data}
 
     elif category == 'prompts':
@@ -294,24 +309,53 @@ async def make_mcp_request(
                     click.echo(f"Server: {init_result.serverInfo.name} {init_result.serverInfo.version}", err=True)
                     click.echo("", err=True)
 
+                # MCP 2025-11-25 §Lifecycle/Operation: both parties MUST only use
+                # capabilities that were successfully negotiated.
+                category = method.split('/')[0]
+                if category in ("tools", "resources", "prompts"):
+                    if getattr(init_result.capabilities, category, None) is None:
+                        available = [
+                            cap for cap in ["tools", "resources", "prompts", "logging", "completions"]
+                            if getattr(init_result.capabilities, cap, None) is not None
+                        ]
+                        raise ValueError(
+                            f"Server does not support '{category}'. Supported: {', '.join(available)}"
+                        )
+
+                # List operations use cursor-based pagination (MCP 2025-11-25).
+                # We collect all pages so the caller gets the complete result set.
+                # Guard against buggy servers that repeat or cycle cursors.
+                MAX_PAGES = 1000
+
+                async def _collect_all(fetch_page, extract_items):
+                    """Paginate a list endpoint, returning all items across pages."""
+                    all_items = []
+                    cursor = None
+                    seen_cursors: set = set()
+                    for _ in range(MAX_PAGES):
+                        result = await fetch_page(cursor=cursor)
+                        all_items.extend(extract_items(result))
+                        if not result.nextCursor or result.nextCursor in seen_cursors:
+                            break
+                        seen_cursors.add(result.nextCursor)
+                        cursor = result.nextCursor
+                    return [item.model_dump(mode='json', exclude_none=True) for item in all_items]
+
                 if method == 'tools/list':
-                    result = await session.list_tools()
-                    return [tool.model_dump(mode='json', exclude_none=True) for tool in result.tools]
+                    return await _collect_all(session.list_tools, lambda r: r.tools)
                 elif method == 'tools/call':
                     tool_name = params.get('name')
                     arguments = params.get('arguments', {})
                     result = await session.call_tool(tool_name, arguments)
                     return [content.model_dump(mode='json', exclude_none=True) for content in result.content]
                 elif method == 'resources/list':
-                    result = await session.list_resources()
-                    return [resource.model_dump(mode='json', exclude_none=True) for resource in result.resources]
+                    return await _collect_all(session.list_resources, lambda r: r.resources)
                 elif method == 'resources/read':
                     uri = params.get('uri')
                     result = await session.read_resource(uri)
                     return [content.model_dump(mode='json', exclude_none=True) for content in result.contents]
                 elif method == 'prompts/list':
-                    result = await session.list_prompts()
-                    return [prompt.model_dump(mode='json', exclude_none=True) for prompt in result.prompts]
+                    return await _collect_all(session.list_prompts, lambda r: r.prompts)
                 elif method == 'prompts/get':
                     prompt_name = params.get('name')
                     arguments = params.get('arguments', {})
@@ -398,13 +442,16 @@ PIPELINES:
   murl $S/tools/search -d q=foo | jq '{id:.[0].text}' | murl $S/tools/get -d @-
 
 AUTHENTICATION:
-  OAuth 2.0 (RFC 7591) with PKCE is built in.
+  OAuth 2.0 with PKCE is built in (Dynamic Client Registration or pre-configured).
   Credentials auto-refresh. On 401, re-authenticates and retries once.
 
   murl --login https://server.com/mcp/tools    # First-time auth (opens browser)
   murl https://server.com/mcp/tools            # Uses stored token
   murl --no-auth https://server.com/mcp/tools  # Skip auth
   murl -H "Authorization: Bearer <tok>" <url>  # Manual token
+
+  Pre-configured OAuth:
+  murl --client-id ID --client-secret SECRET --callback-port 8080 --scope openid <url>
 
   Credentials: ~/.murl/credentials/<hash>.json
 
@@ -415,6 +462,10 @@ OPTIONS:
   --format <json|toon>          Output format (default: json, toon for LLMs)
   --login                      Force OAuth re-authentication
   --no-auth                    Skip all authentication
+  --client-id <id>             Pre-registered OAuth client ID (skip DCR)
+  --client-secret <secret>     Pre-registered OAuth client secret (or MURL_CLIENT_SECRET env)
+  --callback-port <port>       Fixed port for OAuth callback redirect URI
+  --scope <scopes>             OAuth scope to request (e.g. "openid profile")
   --version                    Version info
   --upgrade                    Self-upgrade via pip
   -h, --help                   This help
@@ -430,6 +481,30 @@ OUTPUT:
   exit    0=success  1=error  2=invalid args"""
     click.echo(help_text)
     ctx.exit()
+
+
+def _probe_www_authenticate(base_url: str) -> Optional[str]:
+    """Send an unauthenticated POST to the MCP endpoint to elicit a 401.
+
+    Per MCP 2025-11-25 §Protected Resource Metadata Discovery Requirements,
+    the server MUST include the resource_metadata URL in the WWW-Authenticate
+    header on 401 responses.  For servers with complex URLs (encoded ARNs,
+    query parameters), well-known URI construction from the URL alone may fail,
+    so this probe ensures we get the server-provided discovery URL.
+
+    Returns the WWW-Authenticate header value, or None if the probe fails.
+    """
+    try:
+        resp = _httpx.post(
+            base_url,
+            json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            timeout=10,
+        )
+        if resp.status_code == 401:
+            return resp.headers.get("www-authenticate")
+    except _httpx.HTTPError:
+        pass
+    return None
 
 
 @click.command()
@@ -450,8 +525,17 @@ OUTPUT:
               help='Output format (default: json, toon = token-efficient for LLMs)')
 @click.option('--login', is_flag=True, help='Force OAuth re-authentication')
 @click.option('--no-auth', is_flag=True, help='Skip all authentication')
+@click.option('--client-id', default=None, help='Pre-registered OAuth client ID (skips dynamic registration)')
+@click.option('--client-secret', default=None, envvar='MURL_CLIENT_SECRET',
+              help='Pre-registered OAuth client secret (or set MURL_CLIENT_SECRET)')
+@click.option('--callback-port', default=None, type=int,
+              help='Fixed port for OAuth callback (must match registered redirect URI)')
+@click.option('--scope', default=None,
+              help='OAuth scope to request (e.g. "openid profile")')
 def main(url: Optional[str], data_flags: Tuple[str, ...], header_flags: Tuple[str, ...],
-         verbose: bool, output_format: Optional[str], login: bool, no_auth: bool):
+         verbose: bool, output_format: Optional[str], login: bool, no_auth: bool,
+         client_id: Optional[str], client_secret: Optional[str],
+         callback_port: Optional[int], scope: Optional[str]):
     """murl - MCP Curl"""
     if url is None:
         output_error(
@@ -476,6 +560,17 @@ def main(url: Optional[str], data_flags: Tuple[str, ...], header_flags: Tuple[st
         headers = parse_headers(header_flags) if header_flags else {}
 
         # --- Auth ---
+        # Common kwargs for all authorize() calls
+        auth_kwargs = {}
+        if client_id:
+            auth_kwargs["client_id"] = client_id
+        if client_secret:
+            auth_kwargs["client_secret"] = client_secret
+        if callback_port:
+            auth_kwargs["callback_port"] = callback_port
+        if scope:
+            auth_kwargs["scope"] = scope
+
         has_auth_header = any(k.lower() == 'authorization' for k in headers)
         if not no_auth and not has_auth_header:
             if login:
@@ -489,11 +584,17 @@ def main(url: Optional[str], data_flags: Tuple[str, ...], header_flags: Tuple[st
                         creds = refresh_token(creds)
                         save_credentials(base_url, creds)
                     except OAuthError:
-                        creds = authorize(base_url)
+                        # Probe for WWW-Authenticate so discovery has the
+                        # resource_metadata URL (needed for complex server URLs).
+                        www_auth = _probe_www_authenticate(base_url)
+                        creds = authorize(base_url, www_authenticate=www_auth, **auth_kwargs)
                         save_credentials(base_url, creds)
-                headers["Authorization"] = f"Bearer {creds['access_token']}"  # always set, whether refreshed or not
+                headers["Authorization"] = f"Bearer {creds['access_token']}"
             elif login:
-                creds = authorize(base_url)
+                # Probe for WWW-Authenticate so discovery has the
+                # resource_metadata URL (needed for complex server URLs).
+                www_auth = _probe_www_authenticate(base_url)
+                creds = authorize(base_url, www_authenticate=www_auth, **auth_kwargs)
                 save_credentials(base_url, creds)
                 headers["Authorization"] = f"Bearer {creds['access_token']}"
 
@@ -501,18 +602,54 @@ def main(url: Optional[str], data_flags: Tuple[str, ...], header_flags: Tuple[st
         try:
             result = asyncio.run(make_mcp_request(base_url, method, params, headers, verbose))
         except (Exception, ExceptionGroup) as req_err:
-            err_str = str(req_err)
-            # Unwrap ExceptionGroup to check nested exceptions for 401
-            if isinstance(req_err, ExceptionGroup):
-                for exc in req_err.exceptions:
-                    exc_str = str(exc)
-                    if "401" in exc_str or "Unauthorized" in exc_str:
-                        err_str = exc_str
+            # Extract WWW-Authenticate header and 401 status from the exception chain.
+            # The MCP SDK raises httpx.HTTPStatusError (possibly wrapped in ExceptionGroup)
+            # which carries the full HTTP response including headers.
+            www_auth_header = None
+            is_401 = False
+            is_403 = False
+
+            exceptions = req_err.exceptions if isinstance(req_err, ExceptionGroup) else [req_err]
+            for exc in exceptions:
+                # httpx.HTTPStatusError has a .response attribute
+                if hasattr(exc, 'response') and hasattr(exc.response, 'status_code'):
+                    if exc.response.status_code == 401:
+                        is_401 = True
+                        www_auth_header = exc.response.headers.get("www-authenticate")
                         break
-            if not no_auth and ("401" in err_str or "Unauthorized" in err_str):
+                    if exc.response.status_code == 403:
+                        is_403 = True
+                        www_auth_header = exc.response.headers.get("www-authenticate")
+                        break
+                # Fallback: string matching for non-httpx exceptions
+                exc_str = str(exc)
+                if "401" in exc_str or "Unauthorized" in exc_str:
+                    is_401 = True
+                    break
+
+            # MCP 2025-11-25 §Authorization Flow Steps: on 401, discover
+            # metadata via WWW-Authenticate, then run full OAuth flow.
+            if not no_auth and is_401:
                 if verbose:
                     click.echo("Received 401 — initiating OAuth flow...", err=True)
-                creds = authorize(base_url)
+                    if www_auth_header:
+                        click.echo(f"WWW-Authenticate: {www_auth_header}", err=True)
+                creds = authorize(base_url, www_authenticate=www_auth_header, **auth_kwargs)
+                save_credentials(base_url, creds)
+                headers["Authorization"] = f"Bearer {creds['access_token']}"
+                result = asyncio.run(make_mcp_request(base_url, method, params, headers, verbose))
+            # MCP 2025-11-25 §Scope Challenge Handling: on 403 with explicit
+            # insufficient_scope error, parse required scopes and re-authorize.
+            elif not no_auth and is_403:
+                www_params = parse_www_authenticate(www_auth_header) if www_auth_header else {}
+                if www_params.get("error") != "insufficient_scope" or not www_params.get("scope"):
+                    raise
+                if verbose:
+                    click.echo("Received 403 insufficient_scope — re-authorizing...", err=True)
+                    click.echo(f"WWW-Authenticate: {www_auth_header}", err=True)
+                # Merge scope override into auth_kwargs to avoid passing scope twice.
+                reauth_kwargs = {**auth_kwargs, "scope": www_params["scope"]}
+                creds = authorize(base_url, www_authenticate=www_auth_header, **reauth_kwargs)
                 save_credentials(base_url, creds)
                 headers["Authorization"] = f"Bearer {creds['access_token']}"
                 result = asyncio.run(make_mcp_request(base_url, method, params, headers, verbose))

--- a/murl/cli.py
+++ b/murl/cli.py
@@ -22,6 +22,12 @@ from murl import __version__
 from murl.token_store import get_credentials, save_credentials, clear_credentials, is_expired
 from murl.auth import authorize, refresh_token, OAuthError
 
+# Optional TOON format support (pip install mcp-curl[toon])
+try:
+    from toon import encode as toon_encode
+except ImportError:
+    toon_encode = None
+
 
 # Error patterns for connection failures
 # Note: These patterns are based on httpx/httpcore error messages and may need
@@ -350,6 +356,7 @@ OPTIONS:
   -d, --data <key=value|JSON>  Request data (repeatable)
   -H, --header <Key: Value>    HTTP header (repeatable)
   -v, --verbose                Pretty-print output, show request debug info
+  --format <json|toon>          Output format (default: json, toon for LLMs)
   --login                      Force OAuth re-authentication
   --no-auth                    Skip all authentication
   --version                    Version info
@@ -362,7 +369,7 @@ URL PATHS:
   /prompts          List prompts       /prompts/<name>     Get prompt
 
 OUTPUT:
-  stdout  Compact JSON (NDJSON for lists). Pretty-printed with -v.
+  stdout  Compact JSON (NDJSON for lists). Pretty-printed with -v. TOON with --format toon.
   stderr  Errors as {"error":"CODE","message":"...","code":N}
   exit    0=success  1=error  2=invalid args"""
     click.echo(help_text)
@@ -383,10 +390,12 @@ OUTPUT:
               help='Show version')
 @click.option('--upgrade', is_flag=True, callback=run_upgrade, expose_value=False, is_eager=True,
               help='Upgrade murl')
+@click.option('--format', 'output_format', type=click.Choice(['json', 'toon']), default='json',
+              help='Output format (default: json, toon = token-efficient for LLMs)')
 @click.option('--login', is_flag=True, help='Force OAuth re-authentication')
 @click.option('--no-auth', is_flag=True, help='Skip all authentication')
 def main(url: Optional[str], data_flags: Tuple[str, ...], header_flags: Tuple[str, ...],
-         verbose: bool, login: bool, no_auth: bool):
+         verbose: bool, output_format: Optional[str], login: bool, no_auth: bool):
     """murl - MCP Curl"""
     if url is None:
         output_error(
@@ -394,6 +403,14 @@ def main(url: Optional[str], data_flags: Tuple[str, ...], header_flags: Tuple[st
             message="URL argument is required",
             exit_code=ErrorCode.INVALID_ARGUMENT,
             suggestion="Run: murl --help"
+        )
+
+    if output_format != 'json' and verbose:
+        output_error(
+            error_type="INVALID_ARGUMENT",
+            message="--format and --verbose are mutually exclusive",
+            exit_code=ErrorCode.INVALID_ARGUMENT,
+            suggestion="Use --format for alternative output or -v for verbose JSON, not both"
         )
 
     try:
@@ -449,6 +466,16 @@ def main(url: Optional[str], data_flags: Tuple[str, ...], header_flags: Tuple[st
         # --- Output ---
         if verbose:
             click.echo(json.dumps(result, indent=2))
+        elif output_format == 'toon':
+            if toon_encode is None:
+                output_error(
+                    error_type="MISSING_DEPENDENCY",
+                    message="python-toon package is required for --format toon",
+                    exit_code=ErrorCode.GENERAL_ERROR,
+                    suggestion="Install it with: pip install mcp-curl[toon]"
+                )
+                return
+            click.echo(toon_encode(result))
         elif isinstance(result, list):
             for item in result:
                 click.echo(json.dumps(item, separators=(',', ':')))

--- a/murl/cli.py
+++ b/murl/cli.py
@@ -106,19 +106,74 @@ def parse_data_value(value: str) -> Any:
     return value
 
 
+_MAX_FILE_READ_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
+def _read_json_source(source: str) -> dict:
+    """Read a JSON object from stdin (@-) or a file (@path).
+
+    Follows the curl convention: -d @- reads stdin, -d @file reads a file.
+    The content must be a JSON object (dict), not an array or scalar.
+    """
+    path = source[1:]  # strip leading @
+    try:
+        if path == '-':
+            content = sys.stdin.read(_MAX_FILE_READ_BYTES + 1)
+        else:
+            with open(path) as f:
+                content = f.read(_MAX_FILE_READ_BYTES + 1)
+    except OSError as e:
+        raise ValueError(f"Cannot read {source}: {e}") from e
+
+    if len(content) > _MAX_FILE_READ_BYTES:
+        raise ValueError(
+            f"Input from {source} exceeds 10 MB limit"
+        )
+
+    if not content.strip():
+        raise ValueError(f"Empty input from {source}")
+
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON from {source}: {e}") from e
+
+    if not isinstance(parsed, dict):
+        raise ValueError(
+            f"JSON from {source} must be an object, not {type(parsed).__name__}"
+        )
+    return parsed
+
+
 def parse_data_flags(data_flags: Tuple[str, ...]) -> Dict[str, Any]:
     """Parse -d/--data flags into a dictionary.
 
-    Note:
-        JSON objects (starting with '{') are merged into the result.
-        JSON arrays (starting with '[') are not supported as they don't
-        represent key-value pairs needed for MCP arguments.
+    Supports three formats (processed in order, later values override earlier):
+        - key=value       — simple key-value pair with type coercion
+        - {"key": "val"}  — inline JSON object, merged into result
+        - @-              — read JSON object from stdin (curl convention)
+        - @path           — read JSON object from a file
     """
+    # Detect multiple @- (stdin) references before reading anything.
+    # Stdin is a one-shot resource; the second read would always be empty.
+    stdin_count = sum(1 for d in data_flags if d.strip() == '@-')
+    if stdin_count > 1:
+        raise ValueError(
+            "stdin (@-) can only be used once (it is consumed on first read)"
+        )
+
     result = {}
 
     for data in data_flags:
         stripped = data.strip()
-        if stripped.startswith('{'):
+        # Check for key=value first so that e.g. "email=@user" is not
+        # mistaken for a @-source read.
+        if '=' in stripped and not stripped.startswith('{') and not stripped.startswith('['):
+            key, value = data.split('=', 1)
+            result[key] = parse_data_value(value)
+        elif stripped.startswith('@'):
+            result.update(_read_json_source(stripped))
+        elif stripped.startswith('{'):
             try:
                 parsed = json.loads(data)
                 if not isinstance(parsed, dict):
@@ -129,11 +184,7 @@ def parse_data_flags(data_flags: Tuple[str, ...]) -> Dict[str, Any]:
         elif stripped.startswith('['):
             raise ValueError(f"JSON arrays are not supported in -d flag. Use key=value or JSON objects.")
         else:
-            if '=' not in data:
-                raise ValueError(f"Invalid data format: {data}. Expected key=value or JSON")
-
-            key, value = data.split('=', 1)
-            result[key] = parse_data_value(value)
+            raise ValueError(f"Invalid data format: {data}. Expected key=value or JSON")
 
     return result
 
@@ -338,8 +389,13 @@ DESCRIPTION:
 EXAMPLES:
   murl https://server.com/mcp/tools                         # List tools
   murl https://server.com/mcp/tools/echo -d message=hello   # Call tool
+  murl https://server.com/mcp/tools/echo -d @params.json    # Args from file
+  echo '{"message":"hi"}' | murl $S/tools/echo -d @-        # Args from stdin
   murl https://server.com/mcp/resources/path/to/file         # Read resource
   murl https://server.com/mcp/prompts/greeting -d name=Alice # Get prompt
+
+PIPELINES:
+  murl $S/tools/search -d q=foo | jq '{id:.[0].text}' | murl $S/tools/get -d @-
 
 AUTHENTICATION:
   OAuth 2.0 (RFC 7591) with PKCE is built in.
@@ -353,7 +409,7 @@ AUTHENTICATION:
   Credentials: ~/.murl/credentials/<hash>.json
 
 OPTIONS:
-  -d, --data <key=value|JSON>  Request data (repeatable)
+  -d, --data <val>             Request data: key=value, JSON, @file, @- (repeatable)
   -H, --header <Key: Value>    HTTP header (repeatable)
   -v, --verbose                Pretty-print output, show request debug info
   --format <json|toon>          Output format (default: json, toon for LLMs)

--- a/murl/token_store.py
+++ b/murl/token_store.py
@@ -1,25 +1,95 @@
-"""Credential storage for OAuth tokens."""
+"""Credential storage for OAuth tokens.
+
+Supports two backends (like gh CLI):
+  1. System keychain (macOS Keychain, GNOME Keyring / KDE Wallet, Windows
+     Credential Locker) via the ``keyring`` library.
+  2. Plain JSON files in ~/.murl/credentials/ as a fallback when keyring
+     is not installed or no secure backend is available.
+
+Install keychain support with: pip install mcp-curl[keychain]
+"""
 
 import hashlib
 import json
+import logging
 import os
 import time
 from pathlib import Path
 from typing import Optional
 
+logger = logging.getLogger(__name__)
+
 
 CREDENTIALS_DIR = Path.home() / ".murl" / "credentials"
 EXPIRY_BUFFER_SECONDS = 60
+_KEYRING_SERVICE = "murl"
 
 
 def _key_for_url(server_url: str) -> str:
-    """Return a SHA-256 hash of the server URL for use as a filename."""
+    """Return a SHA-256 hash of the server URL for use as a storage key."""
     return hashlib.sha256(server_url.encode()).hexdigest()
 
 
-def get_credentials(server_url: str) -> Optional[dict]:
-    """Load stored credentials for a server URL, or None if not found."""
-    path = CREDENTIALS_DIR / f"{_key_for_url(server_url)}.json"
+def _keyring_available() -> bool:
+    """Check if keyring is installed and has a usable secure backend."""
+    try:
+        import keyring
+        import keyring.errors
+
+        backend = keyring.get_keyring()
+        backend_mod = type(backend).__module__.lower()
+        # The fail and null backends mean no real keychain is available.
+        if "fail" in backend_mod or "null" in backend_mod:
+            return False
+        return True
+    except Exception:
+        return False
+
+
+def _keyring_get(key: str) -> Optional[dict]:
+    """Read credentials from the system keychain.
+
+    Returns the parsed credentials dict, None if the key is not found,
+    or raises on backend errors so the caller can decide how to handle
+    the failure.
+    """
+    import keyring
+
+    data = keyring.get_password(_KEYRING_SERVICE, key)
+    if data is None:
+        return None
+    return json.loads(data)
+
+
+def _keyring_set(key: str, creds: dict) -> bool:
+    """Write credentials to the system keychain. Returns True on success."""
+    try:
+        import keyring
+
+        keyring.set_password(_KEYRING_SERVICE, key, json.dumps(creds))
+        return True
+    except Exception:
+        return False
+
+
+def _keyring_delete(key: str) -> bool:
+    """Delete credentials from the system keychain. Returns True on success."""
+    try:
+        import keyring
+        import keyring.errors
+
+        keyring.delete_password(_KEYRING_SERVICE, key)
+        return True
+    except keyring.errors.PasswordDeleteError:
+        # Entry did not exist — nothing to delete, considered success.
+        return True
+    except Exception:
+        return False
+
+
+def _file_get(key: str) -> Optional[dict]:
+    """Read credentials from a JSON file."""
+    path = CREDENTIALS_DIR / f"{key}.json"
     if not path.exists():
         return None
     try:
@@ -29,29 +99,96 @@ def get_credentials(server_url: str) -> Optional[dict]:
         return None
 
 
-def save_credentials(server_url: str, creds: dict) -> None:
-    """Persist credentials for a server URL."""
+def _file_set(key: str, creds: dict) -> None:
+    """Write credentials to a JSON file with restrictive permissions."""
     CREDENTIALS_DIR.mkdir(parents=True, exist_ok=True)
     try:
         os.chmod(CREDENTIALS_DIR, 0o700)
     except OSError:
-        pass  # Best-effort directory permissions
-    path = CREDENTIALS_DIR / f"{_key_for_url(server_url)}.json"
+        pass
+    path = CREDENTIALS_DIR / f"{key}.json"
+    # Create file with 0600 from the start to avoid a brief window where
+    # tokens are world-readable under a permissive umask.
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        json.dump(creds, f, indent=2)
+
+
+def _file_delete(key: str) -> bool:
+    """Delete a credential file. Returns True on success."""
+    try:
+        (CREDENTIALS_DIR / f"{key}.json").unlink(missing_ok=True)
+        return True
+    except OSError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def get_credentials(server_url: str) -> Optional[dict]:
+    """Load stored credentials for a server URL, or None if not found.
+
+    Tries the system keychain first, then falls back to the filesystem.
+    """
+    key = _key_for_url(server_url)
+    if _keyring_available():
+        try:
+            creds = _keyring_get(key)
+            if creds is not None:
+                return creds
+        except Exception:
+            logger.warning(
+                "Failed to read credentials from system keychain; "
+                "falling back to file-based credential storage"
+            )
+    # Fallback (or migration path): check filesystem.
+    return _file_get(key)
+
+
+def save_credentials(server_url: str, creds: dict) -> None:
+    """Persist credentials for a server URL.
+
+    Saves to the system keychain if available, otherwise to a file.
+    When saving to keychain, removes any stale credential file.
+    """
+    key = _key_for_url(server_url)
     data_to_save = dict(creds)
     data_to_save["server_url"] = server_url
-    with open(path, "w") as f:
-        json.dump(data_to_save, f, indent=2)
-    try:
-        os.chmod(path, 0o600)
-    except OSError:
-        pass  # Best-effort permissions
+
+    if _keyring_available() and _keyring_set(key, data_to_save):
+        # Clean up any legacy file now that creds live in the keychain.
+        _file_delete(key)
+        return
+    # Fallback: write to filesystem.
+    _file_set(key, data_to_save)
 
 
-def clear_credentials(server_url: str) -> None:
-    """Delete stored credentials for a server URL."""
-    path = CREDENTIALS_DIR / f"{_key_for_url(server_url)}.json"
-    if path.exists():
-        path.unlink()
+def clear_credentials(server_url: str) -> bool:
+    """Delete stored credentials for a server URL from all backends.
+
+    Returns True if all applicable deletions succeeded.  Returns False
+    (and logs a warning) if any backend failed to delete, but never
+    raises so the logout flow is not interrupted.
+    """
+    key = _key_for_url(server_url)
+    success = True
+
+    if _keyring_available():
+        if not _keyring_delete(key):
+            logger.warning(
+                "Failed to delete credentials from system keychain"
+            )
+            success = False
+
+    if not _file_delete(key):
+        logger.warning(
+            "Failed to delete credentials from file storage"
+        )
+        success = False
+
+    return success
 
 
 def is_expired(creds: dict) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-curl"
-version = "0.3.2"
+version = "0.4.0"
 description = "A curl-like CLI tool for interacting with Model Context Protocol (MCP) servers"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -35,10 +35,14 @@ Repository = "https://github.com/turlockmike/murl"
 Issues = "https://github.com/turlockmike/murl/issues"
 
 [project.optional-dependencies]
+toon = [
+    "python-toon>=0.1.3,<1.0.0",
+]
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "requests>=2.31.0",
+    "python-toon>=0.1.3,<1.0.0",  # keep in sync with [toon] extras above
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ Repository = "https://github.com/turlockmike/murl"
 Issues = "https://github.com/turlockmike/murl/issues"
 
 [project.optional-dependencies]
+keychain = [
+    "keyring>=25.0.0",
+]
 toon = [
     "python-toon>=0.1.3,<1.0.0",
 ]
@@ -42,6 +45,7 @@ dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "requests>=2.31.0",
+    "keyring>=25.0.0",  # keep in sync with [keychain] extras above
     "python-toon>=0.1.3,<1.0.0",  # keep in sync with [toon] extras above
 ]
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -274,6 +274,30 @@ class TestDiscoverMetadata:
             # Should have tried multiple URLs (RFC 8414 + OIDC)
             assert mock_get.call_count >= 2
 
+    def test_host_level_fallback_for_pathed_url(self):
+        """Pathed server URL falls back to host-level metadata when path-aware URLs fail.
+
+        Models mcp.atlassian.com: path-prefixed well-known URLs return 401/404,
+        but the host root publishes a single OAuth metadata document.
+        """
+        meta = {
+            "authorization_endpoint": "https://mcp.example.com/authorize",
+            "token_endpoint": "https://mcp.example.com/token",
+            "code_challenge_methods_supported": ["S256"],
+        }
+        with patch("murl.auth.httpx.get") as mock_get:
+            not_found = MagicMock()
+            not_found.status_code = 404
+            host_root = MagicMock()
+            host_root.status_code = 200
+            host_root.json.return_value = meta
+            # Three path-aware attempts fail, then the host-level RFC 8414 URL succeeds.
+            mock_get.side_effect = [not_found, not_found, not_found, host_root]
+
+            result = discover_metadata("https://mcp.example.com/v1/mcp")
+            assert result == meta
+            assert mock_get.call_args_list[3][0][0] == "https://mcp.example.com/.well-known/oauth-authorization-server"
+
 
 # ---------------------------------------------------------------------------
 # register_client
@@ -606,6 +630,34 @@ class TestDiscoverAuthServerMetadata:
 
             with pytest.raises(OAuthError, match="Could not discover Authorization Server"):
                 discover_auth_server_metadata("https://auth.example.com")
+
+    def test_host_level_fallback_for_pathed_issuer(self):
+        """Issuer with path falls back to host-level metadata when path-aware URLs fail.
+
+        Models mcp.atlassian.com: path-prefixed well-known URLs return 401/404,
+        but the host root publishes a single OAuth metadata document.
+        """
+        meta = {
+            "issuer": "https://mcp.example.com",
+            "authorization_endpoint": "https://mcp.example.com/authorize",
+            "token_endpoint": "https://mcp.example.com/token",
+            "code_challenge_methods_supported": ["S256"],
+        }
+        with patch("murl.auth.httpx.get") as mock_get:
+            not_found = MagicMock()
+            not_found.status_code = 404
+            host_root = MagicMock()
+            host_root.status_code = 200
+            host_root.json.return_value = meta
+            # Three path-aware attempts fail, then the host-level RFC 8414 URL succeeds.
+            mock_get.side_effect = [not_found, not_found, not_found, host_root]
+
+            result = discover_auth_server_metadata("https://mcp.example.com/v1/mcp")
+            assert result["token_endpoint"] == "https://mcp.example.com/token"
+            assert result["code_challenge_methods_supported"] == ["S256"]
+            assert result["_discovery_source"] == "rfc8414"
+            # Fourth attempt should be the host-level RFC 8414 URL.
+            assert mock_get.call_args_list[3][0][0] == "https://mcp.example.com/.well-known/oauth-authorization-server"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -21,17 +21,50 @@ from murl.token_store import (
     save_credentials,
     clear_credentials,
     is_expired,
+    _keyring_available,
+    _KEYRING_SERVICE,
+    _key_for_url,
 )
 
+import json
+
 
 # ---------------------------------------------------------------------------
-# token_store tests
+# token_store tests — helpers
 # ---------------------------------------------------------------------------
 
-class TestTokenStore:
-    """Tests for credential persistence."""
+def _mock_keyring_get(store, key):
+    """In-memory keyring get."""
+    data = store.get((_KEYRING_SERVICE, key))
+    if data is None:
+        return None
+    try:
+        return json.loads(data)
+    except Exception:
+        return None
+
+
+def _mock_keyring_set(store, key, creds):
+    """In-memory keyring set."""
+    store[(_KEYRING_SERVICE, key)] = json.dumps(creds)
+    return True
+
+
+def _mock_keyring_delete(store, key):
+    """In-memory keyring delete."""
+    store.pop((_KEYRING_SERVICE, key), None)
+
+
+def _disable_keyring(monkeypatch):
+    """Force the filesystem backend by making keyring appear unavailable."""
+    monkeypatch.setattr("murl.token_store._keyring_available", lambda: False)
+
+
+class TestTokenStoreFilesystem:
+    """Tests for credential persistence via filesystem (no keyring)."""
 
     def test_roundtrip(self, tmp_path, monkeypatch):
+        _disable_keyring(monkeypatch)
         monkeypatch.setattr("murl.token_store.CREDENTIALS_DIR", tmp_path)
         url = "https://example.com/mcp"
         creds = {"access_token": "tok123", "expires_at": time.time() + 3600}
@@ -41,8 +74,11 @@ class TestTokenStore:
         loaded = get_credentials(url)
         assert loaded["access_token"] == "tok123"
         assert loaded["server_url"] == url
+        # Verify it's on disk
+        assert len(list(tmp_path.glob("*.json"))) == 1
 
     def test_clear(self, tmp_path, monkeypatch):
+        _disable_keyring(monkeypatch)
         monkeypatch.setattr("murl.token_store.CREDENTIALS_DIR", tmp_path)
         url = "https://example.com/mcp"
         save_credentials(url, {"access_token": "tok"})
@@ -50,20 +86,110 @@ class TestTokenStore:
         assert get_credentials(url) is None
 
     def test_clear_nonexistent(self, tmp_path, monkeypatch):
+        _disable_keyring(monkeypatch)
         monkeypatch.setattr("murl.token_store.CREDENTIALS_DIR", tmp_path)
         clear_credentials("https://nope.example.com")  # should not raise
 
-    def test_is_expired_true(self):
+
+class TestTokenStoreKeyring:
+    """Tests for credential persistence via system keychain."""
+
+    def _mock_keyring(self, monkeypatch):
+        """Set up an in-memory keyring mock and enable it."""
+        store = {}
+
+        def get_password(service, key):
+            return store.get((service, key))
+
+        def set_password(service, key, value):
+            store[(service, key)] = value
+
+        def delete_password(service, key):
+            store.pop((service, key), None)
+
+        mock_keyring = MagicMock()
+        mock_keyring.get_password = get_password
+        mock_keyring.set_password = set_password
+        mock_keyring.delete_password = delete_password
+
+        monkeypatch.setattr("murl.token_store._keyring_available", lambda: True)
+        import murl.token_store as ts
+        monkeypatch.setattr(ts, "_keyring_get", lambda key: _mock_keyring_get(store, key))
+        monkeypatch.setattr(ts, "_keyring_set", lambda key, creds: _mock_keyring_set(store, key, creds))
+        monkeypatch.setattr(ts, "_keyring_delete", lambda key: _mock_keyring_delete(store, key))
+        return store
+
+    def test_roundtrip(self, tmp_path, monkeypatch):
+        self._mock_keyring(monkeypatch)
+        monkeypatch.setattr("murl.token_store.CREDENTIALS_DIR", tmp_path)
+        url = "https://example.com/mcp"
+        creds = {"access_token": "tok_keyring", "expires_at": time.time() + 3600}
+
+        assert get_credentials(url) is None
+        save_credentials(url, creds)
+        loaded = get_credentials(url)
+        assert loaded["access_token"] == "tok_keyring"
+        assert loaded["server_url"] == url
+        # No file should exist — creds are in the keychain.
+        assert len(list(tmp_path.glob("*.json"))) == 0
+
+    def test_clear(self, tmp_path, monkeypatch):
+        self._mock_keyring(monkeypatch)
+        monkeypatch.setattr("murl.token_store.CREDENTIALS_DIR", tmp_path)
+        url = "https://example.com/mcp"
+        save_credentials(url, {"access_token": "tok"})
+        clear_credentials(url)
+        assert get_credentials(url) is None
+
+    def test_migration_from_file(self, tmp_path, monkeypatch):
+        """Credentials saved to file are readable once keyring is enabled."""
+        # First, save to filesystem.
+        _disable_keyring(monkeypatch)
+        monkeypatch.setattr("murl.token_store.CREDENTIALS_DIR", tmp_path)
+        url = "https://example.com/mcp"
+        save_credentials(url, {"access_token": "old_file_tok"})
+        assert len(list(tmp_path.glob("*.json"))) == 1
+
+        # Now enable keyring — get should find the file credential.
+        self._mock_keyring(monkeypatch)
+        loaded = get_credentials(url)
+        assert loaded["access_token"] == "old_file_tok"
+
+        # Re-saving moves it to keychain and cleans up the file.
+        save_credentials(url, {"access_token": "new_keyring_tok"})
+        loaded = get_credentials(url)
+        assert loaded["access_token"] == "new_keyring_tok"
+        assert len(list(tmp_path.glob("*.json"))) == 0
+
+    def test_keyring_failure_falls_back_to_file(self, tmp_path, monkeypatch):
+        """If keyring save fails, credentials go to a file instead."""
+        monkeypatch.setattr("murl.token_store._keyring_available", lambda: True)
+        import murl.token_store as ts
+        monkeypatch.setattr(ts, "_keyring_set", lambda key, creds: False)
+        monkeypatch.setattr(ts, "_keyring_get", lambda key: None)
+        monkeypatch.setattr(ts, "_keyring_delete", lambda key: None)
+        monkeypatch.setattr("murl.token_store.CREDENTIALS_DIR", tmp_path)
+
+        url = "https://example.com/mcp"
+        save_credentials(url, {"access_token": "fallback_tok"})
+        # Should have fallen back to file.
+        assert len(list(tmp_path.glob("*.json"))) == 1
+
+
+class TestIsExpired:
+    """Tests for token expiry checks."""
+
+    def test_expired(self):
         assert is_expired({"expires_at": time.time() - 10})
 
-    def test_is_expired_false(self):
+    def test_not_expired(self):
         assert not is_expired({"expires_at": time.time() + 3600})
 
-    def test_is_expired_within_buffer(self):
+    def test_within_buffer(self):
         # Expires in 30s — within the 60s buffer
         assert is_expired({"expires_at": time.time() + 30})
 
-    def test_is_expired_missing(self):
+    def test_missing(self):
         assert is_expired({})
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,8 +9,13 @@ import httpx
 
 from murl.auth import (
     _auth_base_url,
+    _canonical_resource_uri,
     _generate_pkce,
+    _validate_auth_server_origin,
     discover_metadata,
+    discover_resource_metadata,
+    discover_auth_server_metadata,
+    parse_www_authenticate,
     register_client,
     authorize,
     refresh_token,
@@ -235,7 +240,9 @@ class TestDiscoverMetadata:
 
             result = discover_metadata("https://example.com/mcp")
             assert result == meta
-            mock_get.assert_called_once()
+            # First URL tried should be path-aware RFC 8414
+            first_url = mock_get.call_args_list[0][0][0]
+            assert "/.well-known/oauth-authorization-server/mcp" in first_url
 
     def test_fallback_on_404(self):
         with patch("murl.auth.httpx.get") as mock_get:
@@ -253,15 +260,19 @@ class TestDiscoverMetadata:
             result = discover_metadata("https://example.com/mcp")
             assert "authorization_endpoint" in result
 
-    def test_error_on_500(self):
+    def test_fallback_on_500(self):
+        """All endpoints returning 500 falls back to defaults (tries multiple URLs)."""
         with patch("murl.auth.httpx.get") as mock_get:
             mock_resp = MagicMock()
             mock_resp.status_code = 500
             mock_resp.text = "Internal Server Error"
             mock_get.return_value = mock_resp
 
-            with pytest.raises(OAuthError, match="Failed to fetch OAuth metadata"):
-                discover_metadata("https://example.com/mcp")
+            result = discover_metadata("https://example.com/mcp")
+            assert "/authorize" in result["authorization_endpoint"]
+            assert "/token" in result["token_endpoint"]
+            # Should have tried multiple URLs (RFC 8414 + OIDC)
+            assert mock_get.call_count >= 2
 
 
 # ---------------------------------------------------------------------------
@@ -305,6 +316,11 @@ class TestRegisterClient:
 # ---------------------------------------------------------------------------
 
 class TestRefreshToken:
+    """MCP 2025-11-25 §Resource Parameter Implementation / RFC 8707.
+
+    refresh_token() MUST include the ``resource`` parameter in the token
+    request so that the refreshed access token is audience-bound.
+    """
 
     def test_success(self):
         creds = {
@@ -312,6 +328,7 @@ class TestRefreshToken:
             "client_secret": None,
             "refresh_token": "rt_old",
             "token_endpoint": "https://auth.example.com/token",
+            "resource_uri": "https://mcp.example.com/mcp",
         }
 
         with patch("murl.auth.httpx.post") as mock_post:
@@ -328,6 +345,79 @@ class TestRefreshToken:
             assert updated["access_token"] == "new_at"
             assert updated["refresh_token"] == "new_rt"
             assert updated["expires_at"] > time.time()
+
+    def test_resource_included_in_refresh_request(self):
+        """RFC 8707: resource MUST be sent in token requests including refresh."""
+        creds = {
+            "client_id": "cid",
+            "client_secret": None,
+            "refresh_token": "rt_old",
+            "token_endpoint": "https://auth.example.com/token",
+            "resource_uri": "https://mcp.example.com/mcp",
+        }
+
+        with patch("murl.auth.httpx.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {
+                "access_token": "new_at",
+                "expires_in": 3600,
+            }
+            mock_post.return_value = mock_resp
+
+            refresh_token(creds)
+
+            post_data = mock_post.call_args[1].get("data", {})
+            assert post_data["resource"] == "https://mcp.example.com/mcp"
+
+    def test_resource_omitted_when_missing_from_creds(self):
+        """Legacy creds without resource_uri should not break refresh."""
+        creds = {
+            "client_id": "cid",
+            "client_secret": None,
+            "refresh_token": "rt_old",
+            "token_endpoint": "https://auth.example.com/token",
+            # No resource_uri — pre-existing creds from before spec update
+        }
+
+        with patch("murl.auth.httpx.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {
+                "access_token": "new_at",
+                "expires_in": 3600,
+            }
+            mock_post.return_value = mock_resp
+
+            refresh_token(creds)
+
+            post_data = mock_post.call_args[1].get("data", {})
+            assert "resource" not in post_data
+
+    def test_client_secret_included_in_refresh(self):
+        """Confidential clients (pre-configured) MUST send client_secret on refresh."""
+        creds = {
+            "client_id": "cid",
+            "client_secret": "sec123",
+            "refresh_token": "rt_old",
+            "token_endpoint": "https://auth.example.com/token",
+            "resource_uri": "https://mcp.example.com/mcp",
+        }
+
+        with patch("murl.auth.httpx.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {
+                "access_token": "new_at",
+                "expires_in": 3600,
+            }
+            mock_post.return_value = mock_resp
+
+            refresh_token(creds)
+
+            post_data = mock_post.call_args[1].get("data", {})
+            assert post_data["client_secret"] == "sec123"
+            assert post_data["resource"] == "https://mcp.example.com/mcp"
 
     def test_no_refresh_token(self):
         with pytest.raises(OAuthError, match="No refresh token"):
@@ -352,10 +442,255 @@ class TestRefreshToken:
 
 
 # ---------------------------------------------------------------------------
+# parse_www_authenticate
+# ---------------------------------------------------------------------------
+
+class TestParseWwwAuthenticate:
+
+    def test_bearer_with_resource_metadata(self):
+        header = 'Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource", scope="files:read"'
+        result = parse_www_authenticate(header)
+        assert result["resource_metadata"] == "https://mcp.example.com/.well-known/oauth-protected-resource"
+        assert result["scope"] == "files:read"
+
+    def test_bearer_with_error(self):
+        header = 'Bearer error="insufficient_scope", scope="files:read files:write", error_description="Need write access"'
+        result = parse_www_authenticate(header)
+        assert result["error"] == "insufficient_scope"
+        assert result["scope"] == "files:read files:write"
+        assert result["error_description"] == "Need write access"
+
+    def test_bare_bearer(self):
+        result = parse_www_authenticate("Bearer")
+        assert result == {}
+
+    def test_empty(self):
+        result = parse_www_authenticate("")
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# discover_resource_metadata (RFC 9728)
+# ---------------------------------------------------------------------------
+
+class TestDiscoverResourceMetadata:
+
+    def test_from_explicit_url(self):
+        meta = {
+            "resource": "https://mcp.example.com/mcp",
+            "authorization_servers": ["https://auth.example.com"],
+        }
+        with patch("murl.auth.httpx.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = meta
+            mock_get.return_value = mock_resp
+
+            result = discover_resource_metadata(
+                "https://mcp.example.com/mcp",
+                resource_metadata_url="https://mcp.example.com/.well-known/oauth-protected-resource/mcp"
+            )
+            assert result["authorization_servers"] == ["https://auth.example.com"]
+            # Should use the explicit URL first
+            mock_get.assert_called_once_with(
+                "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+                follow_redirects=True, timeout=10
+            )
+
+    def test_well_known_path_aware(self):
+        meta = {
+            "resource": "https://mcp.example.com/mcp",
+            "authorization_servers": ["https://auth.example.com"],
+        }
+        with patch("murl.auth.httpx.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = meta
+            mock_get.return_value = mock_resp
+
+            result = discover_resource_metadata("https://mcp.example.com/mcp")
+            assert result["authorization_servers"] == ["https://auth.example.com"]
+            first_url = mock_get.call_args_list[0][0][0]
+            assert first_url == "https://mcp.example.com/.well-known/oauth-protected-resource/mcp"
+
+    def test_fallback_to_root(self):
+        """If path-aware URL fails, try root well-known."""
+        with patch("murl.auth.httpx.get") as mock_get:
+            not_found = MagicMock()
+            not_found.status_code = 404
+            root_meta = MagicMock()
+            root_meta.status_code = 200
+            root_meta.json.return_value = {
+                "authorization_servers": ["https://auth.example.com"],
+            }
+            mock_get.side_effect = [not_found, root_meta]
+
+            result = discover_resource_metadata("https://mcp.example.com/mcp")
+            assert result["authorization_servers"] == ["https://auth.example.com"]
+            assert mock_get.call_count == 2
+
+    def test_all_fail_raises(self):
+        with patch("murl.auth.httpx.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 404
+            mock_get.return_value = mock_resp
+
+            with pytest.raises(OAuthError, match="Protected Resource Metadata"):
+                discover_resource_metadata("https://mcp.example.com/mcp")
+
+
+# ---------------------------------------------------------------------------
+# discover_auth_server_metadata (RFC 8414 + OIDC)
+# ---------------------------------------------------------------------------
+
+class TestDiscoverAuthServerMetadata:
+
+    def test_rfc8414_success(self):
+        meta = {
+            "issuer": "https://auth.example.com",
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+        }
+        with patch("murl.auth.httpx.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = meta
+            mock_get.return_value = mock_resp
+
+            result = discover_auth_server_metadata("https://auth.example.com")
+            assert result["token_endpoint"] == "https://auth.example.com/token"
+            assert result["_discovery_source"] == "rfc8414"
+
+    def test_oidc_fallback(self):
+        """RFC 8414 fails, OIDC discovery succeeds."""
+        meta = {
+            "issuer": "https://auth.example.com",
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+        }
+        with patch("murl.auth.httpx.get") as mock_get:
+            not_found = MagicMock()
+            not_found.status_code = 404
+            oidc_resp = MagicMock()
+            oidc_resp.status_code = 200
+            oidc_resp.json.return_value = meta
+            mock_get.side_effect = [not_found, oidc_resp]
+
+            result = discover_auth_server_metadata("https://auth.example.com")
+            assert result["token_endpoint"] == "https://auth.example.com/token"
+            assert result["_discovery_source"] == "oidc"
+            assert mock_get.call_count == 2
+
+    def test_with_path_component(self):
+        """Issuer URL with path uses path-insertion for both RFC 8414 and OIDC."""
+        meta = {
+            "issuer": "https://auth.example.com/tenant1",
+            "authorization_endpoint": "https://auth.example.com/tenant1/authorize",
+            "token_endpoint": "https://auth.example.com/tenant1/token",
+        }
+        with patch("murl.auth.httpx.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = meta
+            mock_get.return_value = mock_resp
+
+            result = discover_auth_server_metadata("https://auth.example.com/tenant1")
+            first_url = mock_get.call_args_list[0][0][0]
+            assert first_url == "https://auth.example.com/.well-known/oauth-authorization-server/tenant1"
+
+    def test_all_fail_raises(self):
+        with patch("murl.auth.httpx.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 404
+            mock_get.return_value = mock_resp
+
+            with pytest.raises(OAuthError, match="Could not discover Authorization Server"):
+                discover_auth_server_metadata("https://auth.example.com")
+
+
+# ---------------------------------------------------------------------------
+# _validate_auth_server_origin (RFC 9728 §3)
+# ---------------------------------------------------------------------------
+
+class TestValidateAuthServerOrigin:
+    """Prevent redirect attacks via crafted authorization_servers values."""
+
+    def test_same_host_passes(self):
+        _validate_auth_server_origin(
+            "https://example.com/oauth2", "https://example.com/mcp"
+        )
+
+    def test_same_host_different_port_passes(self):
+        """Port differs but hostname matches — allowed."""
+        _validate_auth_server_origin(
+            "https://example.com:8443/oauth", "https://example.com/mcp"
+        )
+
+    def test_case_insensitive(self):
+        _validate_auth_server_origin(
+            "https://Example.COM/oauth", "https://example.com/mcp"
+        )
+
+    def test_different_host_raises(self):
+        with pytest.raises(OAuthError, match="does not match"):
+            _validate_auth_server_origin(
+                "https://evil.example.com/oauth", "https://mcp.example.com/mcp"
+            )
+
+    def test_attacker_redirect_raises(self):
+        with pytest.raises(OAuthError, match="does not match"):
+            _validate_auth_server_origin(
+                "https://attacker.com", "https://legit-server.com/mcp"
+            )
+
+    def test_invalid_url_raises(self):
+        with pytest.raises(OAuthError, match="Invalid authorization server"):
+            _validate_auth_server_origin("not-a-url", "https://example.com/mcp")
+
+
+# ---------------------------------------------------------------------------
+# canonical_resource_uri
+# ---------------------------------------------------------------------------
+
+class TestCanonicalResourceUri:
+    """MCP 2025-11-25 §Resource Parameter Implementation / RFC 8707 §2.
+
+    The canonical URI MUST NOT include fragments, SHOULD omit trailing slash
+    unless semantically significant, and SHOULD be the most specific URI.
+    """
+
+    def test_simple(self):
+        assert _canonical_resource_uri("https://mcp.example.com/mcp") == "https://mcp.example.com/mcp"
+
+    def test_strips_fragment(self):
+        assert _canonical_resource_uri("https://mcp.example.com/mcp#frag") == "https://mcp.example.com/mcp"
+
+    def test_strips_query(self):
+        assert _canonical_resource_uri("https://mcp.example.com/mcp?foo=bar") == "https://mcp.example.com/mcp"
+
+    def test_no_path_no_trailing_slash(self):
+        """Spec SHOULD: use form without trailing slash (MCP 2025-11-25 §Canonical Server URI)."""
+        assert _canonical_resource_uri("https://mcp.example.com") == "https://mcp.example.com"
+
+    def test_preserves_explicit_path_slash(self):
+        """A trailing slash that was explicitly part of the URL is preserved."""
+        assert _canonical_resource_uri("https://mcp.example.com/") == "https://mcp.example.com/"
+
+    def test_with_port(self):
+        """Port is part of the canonical URI (spec example: https://mcp.example.com:8443)."""
+        assert _canonical_resource_uri("https://mcp.example.com:8443/mcp") == "https://mcp.example.com:8443/mcp"
+
+
+# ---------------------------------------------------------------------------
 # Full authorize flow (mocked)
 # ---------------------------------------------------------------------------
 
 class TestAuthorize:
+    """MCP 2025-11-25 §Authorization Flow Steps — end-to-end flow tests.
+
+    Validates: discovery chain, PKCE enforcement, resource parameter (RFC 8707),
+    client registration priority, and scope selection strategy.
+    """
 
     def _mock_full_flow(self, mock_httpx_get, mock_httpx_post, mock_webbrowser, mock_server):
         """Set up mocks for a successful full OAuth flow."""
@@ -366,6 +701,7 @@ class TestAuthorize:
             "authorization_endpoint": "https://auth.example.com/authorize",
             "token_endpoint": "https://auth.example.com/token",
             "registration_endpoint": "https://auth.example.com/register",
+            "code_challenge_methods_supported": ["S256"],
         }
         mock_httpx_get.return_value = meta_resp
 
@@ -403,6 +739,7 @@ class TestAuthorize:
         assert creds["client_id"] == "cid_test"
         assert creds["expires_at"] > time.time()
         assert creds["server_url"] == "https://example.com/mcp"
+        assert creds["resource_uri"] == "https://example.com/mcp"
 
         # Verify browser was opened with correct params
         mock_browser.assert_called_once()
@@ -414,6 +751,13 @@ class TestAuthorize:
         assert params["code_challenge_method"] == ["S256"]
         assert "state" in params
         assert "code_challenge" in params
+        # RFC 8707: resource parameter must be present
+        assert params["resource"] == ["https://example.com/mcp"]
+
+        # Verify token exchange also included resource parameter
+        token_call = mock_post.call_args_list[1]  # second POST is token exchange
+        token_data = token_call[1].get("data", {})
+        assert token_data["resource"] == "https://example.com/mcp"
 
     @patch("murl.auth._run_callback_server")
     @patch("murl.auth.webbrowser.open")
@@ -425,9 +769,189 @@ class TestAuthorize:
         meta_resp.json.return_value = {
             "authorization_endpoint": "https://auth.example.com/authorize",
             "token_endpoint": "https://auth.example.com/token",
+            "code_challenge_methods_supported": ["S256"],
             # No registration_endpoint
         }
         mock_get.return_value = meta_resp
 
         with pytest.raises(OAuthError, match="registration endpoint"):
             authorize("https://example.com/mcp")
+
+    @patch("murl.auth._run_callback_server")
+    @patch("murl.auth.webbrowser.open")
+    @patch("murl.auth.httpx.post")
+    @patch("murl.auth.httpx.get")
+    def test_pkce_missing_from_metadata(self, mock_get, mock_post, mock_browser, mock_server):
+        """authorize() must refuse if code_challenge_methods_supported is absent."""
+        meta_resp = MagicMock()
+        meta_resp.status_code = 200
+        meta_resp.json.return_value = {
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+            "registration_endpoint": "https://auth.example.com/register",
+            # No code_challenge_methods_supported
+        }
+        mock_get.return_value = meta_resp
+
+        with pytest.raises(OAuthError, match="does not advertise PKCE support"):
+            authorize("https://example.com/mcp")
+
+    @patch("murl.auth._run_callback_server")
+    @patch("murl.auth.webbrowser.open")
+    @patch("murl.auth.httpx.post")
+    @patch("murl.auth.httpx.get")
+    def test_pkce_oidc_missing_proceeds_with_warning(self, mock_get, mock_post, mock_browser, mock_server):
+        """OIDC metadata without code_challenge_methods_supported should warn but proceed.
+
+        OIDC Provider Metadata does not define this field (it's an OAuth 2.0 AS
+        Metadata field).  Major IDPs like Okta fully support S256 PKCE but don't
+        include the field in their OIDC discovery document.
+        """
+        # Resource metadata -> points to auth server (same origin as MCP server)
+        resource_meta_resp = MagicMock()
+        resource_meta_resp.status_code = 200
+        resource_meta_resp.json.return_value = {
+            "authorization_servers": ["https://example.com/oauth2/default"],
+        }
+
+        # Auth server metadata via OIDC (no code_challenge_methods_supported)
+        oidc_resp = MagicMock()
+        oidc_resp.status_code = 200
+        oidc_resp.json.return_value = {
+            "issuer": "https://example.com/oauth2/default",
+            "authorization_endpoint": "https://example.com/oauth2/default/v1/authorize",
+            "token_endpoint": "https://example.com/oauth2/default/v1/token",
+            "registration_endpoint": "https://example.com/oauth2/v1/clients",
+            # No code_challenge_methods_supported — typical for Okta OIDC
+        }
+
+        # RFC 8414 fails (404/405), OIDC path-insert fails, OIDC path-append succeeds
+        not_found = MagicMock()
+        not_found.status_code = 405
+
+        # Order: resource_meta path-aware (succeeds), AS rfc8414, OIDC insert, OIDC append
+        mock_get.side_effect = [resource_meta_resp, not_found, not_found, oidc_resp]
+
+        # Registration + token exchange
+        reg_resp = MagicMock()
+        reg_resp.status_code = 201
+        reg_resp.json.return_value = {"client_id": "cid_oidc"}
+
+        token_resp = MagicMock()
+        token_resp.status_code = 200
+        token_resp.json.return_value = {
+            "access_token": "at_oidc",
+            "refresh_token": "rt_oidc",
+            "expires_in": 3600,
+        }
+        mock_post.side_effect = [reg_resp, token_resp]
+        mock_browser.return_value = True
+        mock_server.return_value = "test_auth_code"
+
+        # Should succeed despite missing code_challenge_methods_supported
+        creds = authorize("https://example.com/mcp")
+        assert creds["access_token"] == "at_oidc"
+
+    @patch("murl.auth._run_callback_server")
+    @patch("murl.auth.webbrowser.open")
+    @patch("murl.auth.httpx.post")
+    @patch("murl.auth.httpx.get")
+    def test_pkce_s256_not_supported(self, mock_get, mock_post, mock_browser, mock_server):
+        """authorize() must refuse if S256 is not in code_challenge_methods_supported."""
+        meta_resp = MagicMock()
+        meta_resp.status_code = 200
+        meta_resp.json.return_value = {
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+            "registration_endpoint": "https://auth.example.com/register",
+            "code_challenge_methods_supported": ["plain"],
+        }
+        mock_get.return_value = meta_resp
+
+        with pytest.raises(OAuthError, match="does not support S256"):
+            authorize("https://example.com/mcp")
+
+    @patch("murl.auth._run_callback_server")
+    @patch("murl.auth.webbrowser.open")
+    @patch("murl.auth.httpx.post")
+    @patch("murl.auth.httpx.get")
+    def test_preconfigured_credentials_skip_registration(self, mock_get, mock_post, mock_browser, mock_server):
+        """Pre-configured client_id skips Dynamic Client Registration."""
+        meta_resp = MagicMock()
+        meta_resp.status_code = 200
+        meta_resp.json.return_value = {
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+            "code_challenge_methods_supported": ["S256"],
+            # No registration_endpoint — should still work with pre-configured creds
+        }
+        mock_get.return_value = meta_resp
+
+        token_resp = MagicMock()
+        token_resp.status_code = 200
+        token_resp.json.return_value = {
+            "access_token": "at_preconfig",
+            "refresh_token": "rt_preconfig",
+            "expires_in": 3600,
+        }
+        mock_post.return_value = token_resp
+        mock_browser.return_value = True
+        mock_server.return_value = "test_auth_code"
+
+        creds = authorize(
+            "https://example.com/mcp",
+            client_id="my-app-id",
+            client_secret="my-app-secret",
+            callback_port=8080,
+        )
+
+        assert creds["access_token"] == "at_preconfig"
+        assert creds["client_id"] == "my-app-id"
+
+        # Only one POST (token exchange) — no registration POST
+        assert mock_post.call_count == 1
+
+        # Verify the auth URL uses the pre-configured client_id and fixed port
+        auth_url = mock_browser.call_args[0][0]
+        params = urllib.parse.parse_qs(urllib.parse.urlparse(auth_url).query)
+        assert params["client_id"] == ["my-app-id"]
+        assert params["redirect_uri"] == ["http://localhost:8080/callback"]
+
+        # Verify token exchange includes client_secret
+        token_data = mock_post.call_args[1].get("data", {})
+        assert token_data["client_secret"] == "my-app-secret"
+
+    @patch("murl.auth._run_callback_server")
+    @patch("murl.auth.webbrowser.open")
+    @patch("murl.auth.httpx.post")
+    @patch("murl.auth.httpx.get")
+    def test_no_registration_and_no_client_id_raises(self, mock_get, mock_post, mock_browser, mock_server):
+        """Without pre-configured creds or a registration endpoint, authorize fails."""
+        meta_resp = MagicMock()
+        meta_resp.status_code = 200
+        meta_resp.json.return_value = {
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+            "code_challenge_methods_supported": ["S256"],
+            # No registration_endpoint
+        }
+        mock_get.return_value = meta_resp
+
+        with pytest.raises(OAuthError, match="--client-id"):
+            authorize("https://example.com/mcp")
+
+    @patch("murl.auth._run_callback_server")
+    @patch("murl.auth.webbrowser.open")
+    @patch("murl.auth.httpx.post")
+    @patch("murl.auth.httpx.get")
+    def test_cross_origin_auth_server_rejected(self, mock_get, mock_post, mock_browser, mock_server):
+        """RFC 9728 §3: reject authorization_servers with a different hostname."""
+        resource_meta_resp = MagicMock()
+        resource_meta_resp.status_code = 200
+        resource_meta_resp.json.return_value = {
+            "authorization_servers": ["https://evil.attacker.com/oauth"],
+        }
+        mock_get.return_value = resource_meta_resp
+
+        with pytest.raises(OAuthError, match="does not match"):
+            authorize("https://legit-server.com/mcp")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -670,3 +670,110 @@ def test_cli_no_auth_skips_all_auth(mcp_server):
     assert not mock_get.called, "get_credentials should NOT be called with --no-auth"
     assert not mock_auth.called, "authorize should NOT be called with --no-auth"
     assert result.exit_code == 0
+
+
+# --- TOON format tests ---
+
+
+def test_toon_output_tools_list(mcp_server):
+    """--format toon outputs TOON format for tools/list."""
+    runner = CliRunner()
+    result = runner.invoke(main, [f"{mcp_server}/tools", "--format", "toon", "--no-auth"])
+
+    assert result.exit_code == 0
+    output = result.output.strip()
+    # Should contain tool names from test server
+    assert 'echo' in output
+    # Should NOT be valid JSON (it's TOON)
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(output)
+
+
+def test_toon_output_tool_call(mcp_server):
+    """--format toon outputs TOON format for tool call results."""
+    runner = CliRunner()
+    result = runner.invoke(main, [
+        f"{mcp_server}/tools/echo",
+        "-d", "message=hello",
+        "--format", "toon", "--no-auth"
+    ])
+
+    assert result.exit_code == 0
+    output = result.output.strip()
+    assert 'hello' in output
+    # Verify output is TOON, not passthrough JSON
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(output)
+
+
+def test_toon_format_verbose_mutually_exclusive(mcp_server):
+    """--format and --verbose together should error."""
+    runner = CliRunner()
+    result = runner.invoke(main, [
+        f"{mcp_server}/tools", "--format", "toon", "-v", "--no-auth"
+    ])
+
+    assert result.exit_code == 2
+    error_obj = json.loads(result.output.strip())
+    assert error_obj["error"] == "INVALID_ARGUMENT"
+    assert "mutually exclusive" in error_obj["message"]
+
+
+def test_toon_roundtrip_tools_list(mcp_server):
+    """TOON output can be decoded back to the original data."""
+    from toon import decode as toon_decode
+
+    runner = CliRunner()
+
+    # Get JSON output
+    json_result = runner.invoke(main, [f"{mcp_server}/tools", "--no-auth"])
+    json_data = parse_ndjson(json_result.output)
+
+    # Get TOON output
+    toon_result = runner.invoke(main, [f"{mcp_server}/tools", "--format", "toon", "--no-auth"])
+    toon_data = toon_decode(toon_result.output.strip())
+
+    assert toon_data == json_data
+
+
+def test_toon_missing_dependency(mcp_server):
+    """--format toon with missing python-toon shows helpful error."""
+    from unittest.mock import patch
+
+    runner = CliRunner()
+    with patch("murl.cli.toon_encode", None):
+        result = runner.invoke(main, [f"{mcp_server}/tools", "--format", "toon", "--no-auth"])
+
+    assert result.exit_code == 1
+    error_obj = json.loads(result.output.strip())
+    assert error_obj["error"] == "MISSING_DEPENDENCY"
+    assert "mcp-curl[toon]" in error_obj["suggestion"]
+
+
+def test_toon_nested_objects(mcp_server):
+    """TOON handles tools with nested inputSchema correctly."""
+    from toon import decode as toon_decode
+
+    runner = CliRunner()
+    toon_result = runner.invoke(main, [f"{mcp_server}/tools", "--format", "toon", "--no-auth"])
+
+    assert toon_result.exit_code == 0
+    decoded = toon_decode(toon_result.output.strip())
+
+    # Verify nested inputSchema survived the roundtrip
+    tools_with_schema = [t for t in decoded if 'inputSchema' in t]
+    assert len(tools_with_schema) > 0
+    for tool in tools_with_schema:
+        assert isinstance(tool['inputSchema'], dict)
+
+
+def test_toon_empty_result(mcp_server):
+    """TOON handles empty list results without error."""
+    from unittest.mock import patch, AsyncMock
+
+    runner = CliRunner()
+    with patch("murl.cli.make_mcp_request", new_callable=AsyncMock, return_value=[]):
+        result = runner.invoke(main, [f"{mcp_server}/tools", "--format", "toon", "--no-auth"])
+
+    assert result.exit_code == 0
+    assert '[0]:' in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -168,6 +168,48 @@ def test_parse_data_flags_invalid_json():
         parse_data_flags(('{"invalid": json}',))
 
 
+def test_parse_data_flags_stdin(monkeypatch):
+    """@- reads a JSON object from stdin."""
+    monkeypatch.setattr('sys.stdin', __import__('io').StringIO('{"key": "from_stdin"}'))
+    result = parse_data_flags(('@-',))
+    assert result == {"key": "from_stdin"}
+
+
+def test_parse_data_flags_stdin_merged_with_flags(monkeypatch):
+    """Explicit -d key=value overrides stdin values (later flags win)."""
+    monkeypatch.setattr('sys.stdin', __import__('io').StringIO('{"a": 1, "b": 2}'))
+    result = parse_data_flags(('@-', 'b=99'))
+    assert result == {"a": 1, "b": 99}
+
+
+def test_parse_data_flags_file(tmp_path):
+    """@path reads a JSON object from a file."""
+    f = tmp_path / "args.json"
+    f.write_text('{"name": "from_file", "count": 3}')
+    result = parse_data_flags((f'@{f}',))
+    assert result == {"name": "from_file", "count": 3}
+
+
+def test_parse_data_flags_file_not_found():
+    """@nonexistent gives a clear error."""
+    with pytest.raises(ValueError, match="Cannot read @/no/such/file"):
+        parse_data_flags(('@/no/such/file',))
+
+
+def test_parse_data_flags_stdin_non_object(monkeypatch):
+    """@- with a JSON array (not object) raises ValueError."""
+    monkeypatch.setattr('sys.stdin', __import__('io').StringIO('[1, 2, 3]'))
+    with pytest.raises(ValueError, match="must be an object, not list"):
+        parse_data_flags(('@-',))
+
+
+def test_parse_data_flags_stdin_empty(monkeypatch):
+    """@- with empty stdin raises ValueError."""
+    monkeypatch.setattr('sys.stdin', __import__('io').StringIO(''))
+    with pytest.raises(ValueError, match="Empty input"):
+        parse_data_flags(('@-',))
+
+
 def test_map_tools_list():
     method, params = map_virtual_path_to_method("/tools", {})
     assert method == "tools/list"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -265,6 +265,21 @@ def test_map_resources_read_relative_path():
     assert params == {"uri": "file:///relative/path"}
 
 
+def test_map_resources_read_custom_uri_scheme():
+    """Path containing :// is treated as a full URI, not a file path."""
+    method, params = map_virtual_path_to_method("/resources/https://example.com/data", {})
+    assert method == "resources/read"
+    assert params == {"uri": "https://example.com/data"}
+
+
+def test_map_resources_read_uri_override():
+    """The -d uri=... flag overrides the path-derived URI."""
+    data = {"uri": "git://repo/file.txt"}
+    method, params = map_virtual_path_to_method("/resources/placeholder", data)
+    assert method == "resources/read"
+    assert params["uri"] == "git://repo/file.txt"
+
+
 def test_map_prompts_list():
     method, params = map_virtual_path_to_method("/prompts", {})
     assert method == "prompts/list"
@@ -700,6 +715,57 @@ def test_cli_401_retry_triggers_oauth(mcp_server):
     assert call_count[0] >= 2, "Should retry after 401"
 
 
+def test_cli_403_step_up_triggers_reauth(mcp_server):
+    """A 403 with insufficient_scope triggers re-authorization with required scopes."""
+    from unittest.mock import patch, MagicMock
+    import time as _time
+    import httpx
+
+    fake_creds = {
+        "client_id": "cid",
+        "access_token": "tok_stepup",
+        "refresh_token": "rt",
+        "expires_at": _time.time() + 3600,
+        "token_endpoint": "https://auth.example.com/token",
+        "registration_endpoint": "https://auth.example.com/register",
+        "server_url": "http://localhost",
+    }
+
+    call_count = [0]
+
+    async def mock_make_mcp_request(*args, **kwargs):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            # Simulate a 403 with WWW-Authenticate header
+            mock_response = MagicMock(spec=httpx.Response)
+            mock_response.status_code = 403
+            mock_response.headers = {
+                "www-authenticate": 'Bearer error="insufficient_scope", scope="files:write"'
+            }
+            mock_response.text = "Forbidden"
+            mock_response.stream = MagicMock()
+            raise httpx.HTTPStatusError(
+                "403 Forbidden",
+                request=MagicMock(spec=httpx.Request),
+                response=mock_response,
+            )
+        # Return a successful result on retry
+        return [{"name": "test_tool"}]
+
+    runner = CliRunner()
+    with patch("murl.cli.make_mcp_request", side_effect=mock_make_mcp_request), \
+         patch("murl.cli.authorize", return_value=fake_creds) as mock_auth, \
+         patch("murl.cli.save_credentials"):
+        result = runner.invoke(main, [f"{TEST_SERVER_URL}/tools"])
+
+    assert mock_auth.called, "authorize should be called after 403 insufficient_scope"
+    # Verify scope was passed to authorize
+    _, auth_kwargs = mock_auth.call_args
+    assert auth_kwargs.get("scope") == "files:write", "authorize should be called with the required scope"
+    assert call_count[0] >= 2, "Should retry after 403"
+    assert result.exit_code == 0
+
+
 def test_cli_no_auth_skips_all_auth(mcp_server):
     """--no-auth skips credential loading and OAuth entirely."""
     from unittest.mock import patch
@@ -819,3 +885,242 @@ def test_toon_empty_result(mcp_server):
 
     assert result.exit_code == 0
     assert '[0]:' in result.output
+
+
+def test_cli_unsupported_capability_error():
+    """CLI outputs structured INVALID_ARGUMENT error when server lacks the requested capability."""
+    from unittest.mock import patch, AsyncMock
+
+    runner = CliRunner()
+    with patch(
+        "murl.cli.make_mcp_request",
+        new_callable=AsyncMock,
+        side_effect=ValueError("Server does not support 'resources'. Supported: tools, logging"),
+    ):
+        result = runner.invoke(main, ["http://localhost:8080/resources", "--no-auth"])
+
+    assert result.exit_code == 2
+    error_obj = json.loads(result.output.strip())
+    assert error_obj["error"] == "INVALID_ARGUMENT"
+    assert "Server does not support 'resources'" in error_obj["message"]
+    assert "tools, logging" in error_obj["message"]
+
+
+# ---------------------------------------------------------------------------
+# Pagination tests — MCP 2025-11-25 cursor-based pagination
+# ---------------------------------------------------------------------------
+
+def test_pagination_tools_list():
+    """tools/list must follow nextCursor and collect all pages."""
+    from unittest.mock import patch, AsyncMock, MagicMock
+    from murl.cli import make_mcp_request
+
+    # Build two pages of tools
+    tool_a = MagicMock()
+    tool_a.model_dump.return_value = {"name": "tool_a"}
+    tool_b = MagicMock()
+    tool_b.model_dump.return_value = {"name": "tool_b"}
+    tool_c = MagicMock()
+    tool_c.model_dump.return_value = {"name": "tool_c"}
+
+    page1 = MagicMock()
+    page1.tools = [tool_a, tool_b]
+    page1.nextCursor = "cursor_page2"
+
+    page2 = MagicMock()
+    page2.tools = [tool_c]
+    page2.nextCursor = None
+
+    mock_session = AsyncMock()
+    mock_session.list_tools = AsyncMock(side_effect=[page1, page2])
+    mock_session.initialize = AsyncMock()
+
+    init_result = MagicMock()
+    init_result.capabilities.tools = MagicMock()
+    init_result.capabilities.resources = None
+    init_result.capabilities.prompts = None
+    init_result.protocolVersion = "2025-11-25"
+    init_result.serverInfo.name = "test"
+    init_result.serverInfo.version = "1.0"
+    mock_session.initialize.return_value = init_result
+
+    import contextlib
+
+    @contextlib.asynccontextmanager
+    async def mock_http_client(*args, **kwargs):
+        yield (AsyncMock(), AsyncMock(), MagicMock())
+
+    @contextlib.asynccontextmanager
+    async def mock_client_session(read, write):
+        yield mock_session
+
+    with patch("murl.cli.streamable_http_client", mock_http_client), \
+         patch("murl.cli.ClientSession", mock_client_session):
+        import asyncio
+        result = asyncio.run(make_mcp_request(
+            "http://localhost:8080", "tools/list", {}, {}, False
+        ))
+
+    assert len(result) == 3
+    assert result[0]["name"] == "tool_a"
+    assert result[2]["name"] == "tool_c"
+    # Verify cursor was passed on second call
+    assert mock_session.list_tools.call_count == 2
+    second_call_kwargs = mock_session.list_tools.call_args_list[1]
+    assert second_call_kwargs[1]["cursor"] == "cursor_page2"
+
+
+def test_pagination_resources_list():
+    """resources/list must follow nextCursor and collect all pages."""
+    from unittest.mock import patch, AsyncMock, MagicMock
+    from murl.cli import make_mcp_request
+
+    res_a = MagicMock()
+    res_a.model_dump.return_value = {"uri": "file:///a.txt", "name": "a"}
+    res_b = MagicMock()
+    res_b.model_dump.return_value = {"uri": "file:///b.txt", "name": "b"}
+
+    page1 = MagicMock()
+    page1.resources = [res_a]
+    page1.nextCursor = "page2"
+
+    page2 = MagicMock()
+    page2.resources = [res_b]
+    page2.nextCursor = None
+
+    mock_session = AsyncMock()
+    mock_session.list_resources = AsyncMock(side_effect=[page1, page2])
+    mock_session.initialize = AsyncMock()
+
+    init_result = MagicMock()
+    init_result.capabilities.tools = None
+    init_result.capabilities.resources = MagicMock()
+    init_result.capabilities.prompts = None
+    init_result.protocolVersion = "2025-11-25"
+    init_result.serverInfo.name = "test"
+    init_result.serverInfo.version = "1.0"
+    mock_session.initialize.return_value = init_result
+
+    import contextlib
+
+    @contextlib.asynccontextmanager
+    async def mock_http_client(*args, **kwargs):
+        yield (AsyncMock(), AsyncMock(), MagicMock())
+
+    @contextlib.asynccontextmanager
+    async def mock_client_session(read, write):
+        yield mock_session
+
+    with patch("murl.cli.streamable_http_client", mock_http_client), \
+         patch("murl.cli.ClientSession", mock_client_session):
+        import asyncio
+        result = asyncio.run(make_mcp_request(
+            "http://localhost:8080", "resources/list", {}, {}, False
+        ))
+
+    assert len(result) == 2
+    assert result[0]["name"] == "a"
+    assert result[1]["name"] == "b"
+    assert mock_session.list_resources.call_count == 2
+
+
+def test_pagination_prompts_list():
+    """prompts/list must follow nextCursor and collect all pages."""
+    from unittest.mock import patch, AsyncMock, MagicMock
+    from murl.cli import make_mcp_request
+
+    prompt_a = MagicMock()
+    prompt_a.model_dump.return_value = {"name": "greeting"}
+    prompt_b = MagicMock()
+    prompt_b.model_dump.return_value = {"name": "farewell"}
+
+    page1 = MagicMock()
+    page1.prompts = [prompt_a]
+    page1.nextCursor = "next"
+
+    page2 = MagicMock()
+    page2.prompts = [prompt_b]
+    page2.nextCursor = None
+
+    mock_session = AsyncMock()
+    mock_session.list_prompts = AsyncMock(side_effect=[page1, page2])
+    mock_session.initialize = AsyncMock()
+
+    init_result = MagicMock()
+    init_result.capabilities.tools = None
+    init_result.capabilities.resources = None
+    init_result.capabilities.prompts = MagicMock()
+    init_result.protocolVersion = "2025-11-25"
+    init_result.serverInfo.name = "test"
+    init_result.serverInfo.version = "1.0"
+    mock_session.initialize.return_value = init_result
+
+    import contextlib
+
+    @contextlib.asynccontextmanager
+    async def mock_http_client(*args, **kwargs):
+        yield (AsyncMock(), AsyncMock(), MagicMock())
+
+    @contextlib.asynccontextmanager
+    async def mock_client_session(read, write):
+        yield mock_session
+
+    with patch("murl.cli.streamable_http_client", mock_http_client), \
+         patch("murl.cli.ClientSession", mock_client_session):
+        import asyncio
+        result = asyncio.run(make_mcp_request(
+            "http://localhost:8080", "prompts/list", {}, {}, False
+        ))
+
+    assert len(result) == 2
+    assert result[0]["name"] == "greeting"
+    assert result[1]["name"] == "farewell"
+    assert mock_session.list_prompts.call_count == 2
+
+
+def test_pagination_single_page_no_extra_calls():
+    """When nextCursor is None on first page, no additional requests are made."""
+    from unittest.mock import patch, AsyncMock, MagicMock
+    from murl.cli import make_mcp_request
+
+    tool = MagicMock()
+    tool.model_dump.return_value = {"name": "only_tool"}
+
+    page = MagicMock()
+    page.tools = [tool]
+    page.nextCursor = None
+
+    mock_session = AsyncMock()
+    mock_session.list_tools = AsyncMock(return_value=page)
+    mock_session.initialize = AsyncMock()
+
+    init_result = MagicMock()
+    init_result.capabilities.tools = MagicMock()
+    init_result.capabilities.resources = None
+    init_result.capabilities.prompts = None
+    init_result.protocolVersion = "2025-11-25"
+    init_result.serverInfo.name = "test"
+    init_result.serverInfo.version = "1.0"
+    mock_session.initialize.return_value = init_result
+
+    import contextlib
+
+    @contextlib.asynccontextmanager
+    async def mock_http_client(*args, **kwargs):
+        yield (AsyncMock(), AsyncMock(), MagicMock())
+
+    @contextlib.asynccontextmanager
+    async def mock_client_session(read, write):
+        yield mock_session
+
+    with patch("murl.cli.streamable_http_client", mock_http_client), \
+         patch("murl.cli.ClientSession", mock_client_session):
+        import asyncio
+        result = asyncio.run(make_mcp_request(
+            "http://localhost:8080", "tools/list", {}, {}, False
+        ))
+
+    assert len(result) == 1
+    assert result[0]["name"] == "only_tool"
+    # Only one call — no extra pagination requests
+    assert mock_session.list_tools.call_count == 1


### PR DESCRIPTION
## Summary

When the MCP server URL has a path component (e.g. `https://mcp.atlassian.com/v1/mcp`), `discover_metadata` and `discover_auth_server_metadata` only try path-prefixed `.well-known` URLs. mcp.atlassian.com — and likely other production servers — publish a single OAuth Authorization Server Metadata document at the host root and route 401/404 for path-prefixed well-known URLs. Without a host-level fallback, both functions exhaust their path-aware attempts, fall through to synthetic defaults missing `code_challenge_methods_supported`, and the PKCE check then aborts the flow with:

> Authorization server does not advertise PKCE support (code_challenge_methods_supported). Cannot proceed securely.

This adds a host-level (no path) fallback after the path-aware attempts fail. Path-less URLs are unchanged. The RFC 9728 Protected Resource Metadata path is unaffected — only the legacy direct-discovery and RFC 8414 issuer-discovery paths get the extra attempts.

## Reproduction

Before this change:

```
$ murl https://mcp.atlassian.com/v1/mcp/tools
Discovering OAuth metadata...
{"error": "ERROR", "message": "Authorization server does not advertise PKCE support (code_challenge_methods_supported). Cannot proceed securely.", "code": 1}
```

The Atlassian server actually advertises PKCE correctly at `https://mcp.atlassian.com/.well-known/oauth-authorization-server`, but path-prefixed well-known URLs return 401/404:

```
$ for p in /.well-known/oauth-authorization-server/v1/mcp \
          /v1/mcp/.well-known/oauth-authorization-server \
          /.well-known/openid-configuration/v1/mcp \
          /v1/mcp/.well-known/openid-configuration \
          /.well-known/oauth-authorization-server; do
    printf "%-60s %s\n" "$p" "$(curl -s -o /dev/null -w "%{http_code}" "https://mcp.atlassian.com$p")"
  done
/.well-known/oauth-authorization-server/v1/mcp               404
/v1/mcp/.well-known/oauth-authorization-server               401
/.well-known/openid-configuration/v1/mcp                     404
/v1/mcp/.well-known/openid-configuration                     401
/.well-known/oauth-authorization-server                      200
```

After this change `discover_metadata` and `discover_auth_server_metadata` find the host-level document, surface PKCE support, and the OAuth flow completes:

```
$ murl https://mcp.atlassian.com/v1/mcp/tools
Discovering OAuth metadata...
Registering client...
Opening browser for authorization...
...
Authorization successful!
{"name":"atlassianUserInfo",...}
{"name":"getAccessibleAtlassianResources",...}
...
```

## Test plan

- [x] All 57 existing auth tests pass unchanged
- [x] New test `test_host_level_fallback_for_pathed_issuer` covers `discover_auth_server_metadata`
- [x] New test `test_host_level_fallback_for_pathed_url` covers legacy `discover_metadata`
- [x] End-to-end verified against live `mcp.atlassian.com/v1/mcp` — `tools/list` and `tools/call` both work
- [ ] CI matrix passes on Python 3.10–3.14